### PR TITLE
Replace deprecated queryDataItems() with current query() API

### DIFF
--- a/astro/commerce/src/lib/wix/index.ts
+++ b/astro/commerce/src/lib/wix/index.ts
@@ -332,10 +332,8 @@ export async function getCollections(): Promise<Collection[]> {
 
 export async function getMenu(handle: string): Promise<Menu[]> {
   const { items: menus } = await items
-    .queryDataItems({
-      dataCollectionId: "Menus",
-      includeReferencedItems: ["pages"],
-    })
+    .query("Menus")
+    .include("pages")
     .eq("slug", handle)
     .find()
     .catch((e) => {
@@ -361,9 +359,7 @@ export async function getMenu(handle: string): Promise<Menu[]> {
 
 export async function getPage(handle: string): Promise<Page | undefined> {
   const { items: pages } = await items
-    .queryDataItems({
-      dataCollectionId: "Pages",
-    })
+    .query("Pages")
     .eq("slug", handle)
     .find()
     .catch((e) => {
@@ -400,9 +396,7 @@ export async function getPage(handle: string): Promise<Page | undefined> {
 
 export async function getPages(): Promise<Page[]> {
   const { items: pages } = await items
-    .queryDataItems({
-      dataCollectionId: "Pages2",
-    })
+    .query("Pages2")
     .find()
     .catch((e) => {
       if (e.details.applicationError.code === "WDE0025") {


### PR DESCRIPTION
## Summary
Updates the Wix SDK usage in the Astro commerce template to use the current `query()` API instead of the deprecated `queryDataItems()` method.

## Changes Made
- Updated `getMenu()` to use `items.query('Menus').include('pages')` 
- Updated `getPage()` to use `items.query('Pages')`
- Updated `getPages()` to use `items.query('Pages2')`

## Why This Change
The `queryDataItems()` method has been deprecated and replaced with the `query()` API as documented in the [official Wix SDK docs](https://dev.wix.com/docs/sdk/backend-modules/data/items/query).

## Testing
- ✅ No linting errors introduced
- ✅ Maintains same functionality with updated API
- ✅ Compatible with latest @wix/data package versions

## Related
Resolves TypeError: Class constructor PipelineBuilder cannot be invoked without 'new' which occurs when using deprecated queryDataItems with newer SDK versions.