### PR TITLE
Add SEO tags to astro/commerce product and category pages

### DIFF
--- a/astro/commerce/package.json
+++ b/astro/commerce/package.json
@@ -18,6 +18,7 @@
     "@wix/essentials": "^0.1.23",
     "@wix/redirects": "1.0.60",
     "@wix/sdk": "^1.15.23",
+    "@wix/seo": "^1.0.44",
     "@wix/stores": "^1.0.697",
     "astro": "5.8.0",
     "tailwindcss": "^4.1.7",

--- a/astro/commerce/src/components/layout/layout.astro
+++ b/astro/commerce/src/components/layout/layout.astro
@@ -9,6 +9,7 @@ import "../../styles/global.css";
     <meta charset="utf-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <slot name="seo-tags" />
     <ClientRouter />
   </head>
   <body

--- a/astro/commerce/src/pages/product/[handle].astro
+++ b/astro/commerce/src/pages/product/[handle].astro
@@ -15,9 +15,19 @@ import ProductDescription from "../../components/product/product-description.ast
 import RelatedProducts from "../../components/product/related-products.astro";
 import { getProduct } from "../../lib/wix";
 import { type Image } from "../../lib/wix/types";
+import { SEO } from "@wix/seo/components";
+import { loadSEOTagsServiceConfig } from "@wix/seo/services";
+import { seoTags } from "@wix/seo";
 
 const params = Astro.params;
-const product = await getProduct(params.handle!);
+const [product, seoTagsServiceConfig] = await Promise.all([
+  getProduct(params.handle!),
+  loadSEOTagsServiceConfig({
+    pageUrl: Astro.url.href,
+    itemType: seoTags.ItemType.STORES_PRODUCT,
+    itemData: { slug: params.handle! },
+  }),
+]);
 
 if (!product) return new Response(null, { status: 404 });
 
@@ -40,6 +50,7 @@ const productJsonLd = {
 ---
 
 <Layout>
+  <SEO.Tags seoTagsServiceConfig={seoTagsServiceConfig} slot="seo-tags" />
   <script
     type="application/ld+json"
     set:html={JSON.stringify(productJsonLd)}

--- a/astro/commerce/src/pages/search/[collection].astro
+++ b/astro/commerce/src/pages/search/[collection].astro
@@ -13,20 +13,31 @@ import ProductGridItems from "../../components/layout/product-grid-items.astro";
 import { defaultSort, sorting } from "../../lib/constants";
 import { getCollectionProducts } from "../../lib/wix";
 import SearchLayout from "../../components/layout/search/layout.astro";
+import { SEO } from "@wix/seo/components";
+import { loadSEOTagsServiceConfig } from "@wix/seo/services";
+import { seoTags } from "@wix/seo";
 
 const searchParams = Object.fromEntries(Astro.url.searchParams.entries());
 const params = Astro.params;
 const { sort } = searchParams;
 const { sortKey, reverse } =
   sorting.find((item) => item.slug === sort) || defaultSort;
-const products = await getCollectionProducts({
-  collection: params.collection!,
-  sortKey,
-  reverse,
-});
+const [products, seoTagsServiceConfig] = await Promise.all([
+  getCollectionProducts({
+    collection: params.collection!,
+    sortKey,
+    reverse,
+  }),
+  loadSEOTagsServiceConfig({
+    pageUrl: Astro.url.href,
+    itemType: seoTags.ItemType.STORES_CATEGORY,
+    itemData: { slug: params.collection! },
+  }),
+]);
 ---
 
 <Layout>
+  <SEO.Tags seoTagsServiceConfig={seoTagsServiceConfig} slot="seo-tags" />
   <SearchLayout>
     <section>
       {


### PR DESCRIPTION
## Summary

- Adds `@wix/seo` package to `astro/commerce` dependencies
- Wires a named `seo-tags` slot into `layout.astro` so pages can inject `<head>` tags from SSR
- Product page (`/product/[handle]`) now calls `loadSEOTagsServiceConfig` with `ItemType.STORES_PRODUCT` and renders `<SEO.Tags>` into that slot
- Category page (`/search/[collection]`) now calls `loadSEOTagsServiceConfig` with `ItemType.STORES_CATEGORY` and renders `<SEO.Tags>` into that slot
- Both pages fetch SEO config in parallel with existing data fetches via `Promise.all` to avoid waterfall

## References

- Wix SEO tags API: https://github.com/wix-incubator/kitchensink/blob/main/src/pages/docs/components/seo-tags.mdx

## Test plan

- [ ] Visit a product page and confirm `<title>`, OG tags, and other Wix-managed SEO tags appear in the rendered HTML `<head>`
- [ ] Visit a category/collection page and confirm the same
- [ ] Confirm pages still render correctly when no SEO config is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)