### PR TITLE
Change homepage featured collection slug to all-products

### DIFF
--- a/astro/commerce/src/components/grid/three-items.astro
+++ b/astro/commerce/src/components/grid/three-items.astro
@@ -2,9 +2,8 @@
 import { getCollectionProducts } from "../../lib/wix";
 import ThreeItemGridItem from "./three-item-grid-item.astro";
 
-// Collections that start with `hidden-*` are hidden from the search page.
 const homepageItems = await getCollectionProducts({
-  collection: "hidden-homepage-featured-items",
+  collection: "all-products",
 });
 
 if (!homepageItems[0] || !homepageItems[1] || !homepageItems[2]) return null;


### PR DESCRIPTION
## Summary
- Replaces the hard-coded `hidden-homepage-featured-items` collection slug with `all-products` in `astro/commerce/src/components/grid/three-items.astro`
- Also removes the now-outdated comment about `hidden-*` collections

## Test plan
- [ ] Verify the homepage three-item grid loads products from the `all-products` collection

🤖 Generated with [Claude Code](https://claude.com/claude-code)