### PR TITLE
Refactor astro/commerce template

### DIFF
--- a/astro/commerce/astro.config.mjs
+++ b/astro/commerce/astro.config.mjs
@@ -2,13 +2,14 @@
 import { defineConfig } from "astro/config";
 import wix from "@wix/astro";
 import wixPages from "@wix/astro-pages";
+import react from "@astrojs/react";
 
 import tailwindcss from "@tailwindcss/vite";
 
 // https://astro.build/config
 export default defineConfig({
   output: "server",
-  integrations: [wix(), wixPages()],
+  integrations: [wix(), wixPages(), react()],
   image: {
     domains: ["static.wixstatic.com"],
   },

--- a/astro/commerce/package.json
+++ b/astro/commerce/package.json
@@ -8,6 +8,7 @@
     "build": "astro build"
   },
   "dependencies": {
+    "@astrojs/react": "^5.0.4",
     "@tailwindcss/vite": "^4.1.7",
     "@wix/astro": "^2.13.0",
     "@wix/astro-pages": "^2.0.3",
@@ -21,7 +22,12 @@
     "@wix/seo": "^1.0.44",
     "@wix/stores": "^1.0.697",
     "astro": "5.8.0",
+    "react": "^18",
+    "react-dom": "^18",
     "tailwindcss": "^4.1.7",
     "typescript": "^5.8.3"
+  },
+  "engines": {
+    "node": "24.x"
   }
 }

--- a/astro/commerce/src/components/carousel.astro
+++ b/astro/commerce/src/components/carousel.astro
@@ -1,11 +1,16 @@
 ---
-import { getCollectionProducts } from "../lib/wix";
+import { getCollectionProducts, getProducts } from "../lib/wix";
 import GridTileImage from "./grid/tile.astro";
 
+// Try the curated collection first, then fall back to any products.
 // Collections that start with `hidden-*` are hidden from the search page.
-const products = await getCollectionProducts({
+let products = await getCollectionProducts({
   collection: "hidden-homepage-carousel",
 });
+
+if (!products?.length) {
+  products = await getProducts({});
+}
 
 if (!products?.length) return null;
 
@@ -13,26 +18,51 @@ if (!products?.length) return null;
 const carouselProducts = [...products, ...products, ...products];
 ---
 
-<div class="w-full overflow-x-auto pb-6 pt-1">
-  <ul class="flex animate-carousel gap-4">
-    {
-      carouselProducts.map((product) => (
-        <li class="relative aspect-square h-[30vh] max-h-[275px] w-2/3 max-w-[475px] flex-none md:w-1/3">
-          <a href={`/product/${product.handle}`} class="relative h-full w-full">
-            <GridTileImage
-              alt={product.title}
-              label={{
-                title: product.title,
-                amount: product.priceRange.maxVariantPrice.amount,
-                currencyCode: product.priceRange.maxVariantPrice.currencyCode,
-              }}
-              src={product.featuredImage?.url}
-              inferSize
-              sizes="(min-width: 1024px) 25vw, (min-width: 768px) 33vw, 50vw"
-            />
-          </a>
-        </li>
-      ))
-    }
-  </ul>
-</div>
+<section class="mx-auto w-full max-w-(--breakpoint-2xl) px-4 pb-12 pt-16">
+  <div class="mb-6 flex items-end justify-between border-b border-neutral-200 pb-4 dark:border-neutral-800">
+    <div>
+      <p class="eyebrow text-neutral-500 dark:text-neutral-400">In rotation</p>
+      <h2
+        class="font-display mt-1 text-3xl font-medium tracking-tight md:text-4xl"
+      >
+        Trending now
+      </h2>
+    </div>
+    <a
+      href="/search"
+      class="hidden text-sm font-medium underline underline-offset-4 hover:no-underline md:inline"
+    >
+      Shop all
+    </a>
+  </div>
+  <div
+    class="relative -mx-4 [mask-image:linear-gradient(to_right,transparent_0,black_3rem,black_calc(100%-3rem),transparent_100%)]"
+  >
+    <div class="overflow-x-auto px-4 py-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+      <ul class="flex animate-carousel gap-3 md:gap-4">
+        {
+          carouselProducts.map((product) => (
+            <li class="relative aspect-[3/4] h-[42vh] max-h-[420px] w-[58%] max-w-[340px] flex-none md:w-1/4">
+              <a
+                href={`/product/${product.handle}`}
+                class="block h-full w-full"
+              >
+                <GridTileImage
+                  alt={product.title}
+                  label={{
+                    title: product.title,
+                    amount: product.priceRange.maxVariantPrice.amount,
+                    currencyCode: product.priceRange.maxVariantPrice.currencyCode,
+                  }}
+                  src={product.featuredImage?.url}
+                  inferSize
+                  sizes="(min-width: 1024px) 25vw, (min-width: 768px) 33vw, 50vw"
+                />
+              </a>
+            </li>
+          ))
+        }
+      </ul>
+    </div>
+  </div>
+</section>

--- a/astro/commerce/src/components/grid/three-items.astro
+++ b/astro/commerce/src/components/grid/three-items.astro
@@ -1,21 +1,38 @@
 ---
-import { getCollectionProducts } from "../../lib/wix";
+import { getCollectionProducts, getProducts } from "../../lib/wix";
 import ThreeItemGridItem from "./three-item-grid-item.astro";
 
+// Try the curated collection first, then fall back to any products.
 // Collections that start with `hidden-*` are hidden from the search page.
-const homepageItems = await getCollectionProducts({
+let homepageItems = await getCollectionProducts({
   collection: "hidden-homepage-featured-items",
 });
 
-if (!homepageItems[0] || !homepageItems[1] || !homepageItems[2]) return null;
+if (homepageItems.length < 3) {
+  homepageItems = await getProducts({});
+}
+
+if (homepageItems.length < 3) return null;
 
 const [firstProduct, secondProduct, thirdProduct] = homepageItems;
 ---
 
-<section
-  class="mx-auto grid max-w-(--breakpoint-2xl) gap-4 px-4 pb-4 md:grid-cols-6 md:grid-rows-2 lg:max-h-[calc(100vh-200px)]"
->
-  <ThreeItemGridItem size="full" item={firstProduct} />
-  <ThreeItemGridItem size="half" item={secondProduct} />
-  <ThreeItemGridItem size="half" item={thirdProduct} />
+<section class="mx-auto w-full max-w-(--breakpoint-2xl) px-4 pt-8 pb-4 md:pt-12">
+  <div class="mb-6 flex items-end justify-between md:mb-8">
+    <div>
+      <p class="eyebrow text-neutral-500 dark:text-neutral-400">The edit</p>
+      <h2
+        class="font-display mt-1 text-4xl font-medium tracking-tight md:text-5xl"
+      >
+        Featured pieces
+      </h2>
+    </div>
+  </div>
+  <div
+    class="grid gap-3 md:grid-cols-6 md:grid-rows-2 md:gap-4 lg:max-h-[calc(100vh-160px)]"
+  >
+    <ThreeItemGridItem size="full" item={firstProduct} />
+    <ThreeItemGridItem size="half" item={secondProduct} />
+    <ThreeItemGridItem size="half" item={thirdProduct} />
+  </div>
 </section>

--- a/astro/commerce/src/components/grid/tile.astro
+++ b/astro/commerce/src/components/grid/tile.astro
@@ -18,19 +18,18 @@ type Props = {
 
 <div
   class={clsx(
-    "group flex h-full w-full items-center justify-center overflow-hidden rounded-lg border bg-white hover:border-blue-600 dark:bg-black",
+    "group relative flex h-full w-full items-center justify-center overflow-hidden rounded-md bg-neutral-100 dark:bg-neutral-900",
     {
-      relative: Astro.props.label,
-      "border-2 border-blue-600": Astro.props.active,
-      "border-neutral-200 dark:border-neutral-800": !Astro.props.active,
+      "ring-2 ring-neutral-900 ring-offset-2 ring-offset-neutral-50 dark:ring-neutral-50 dark:ring-offset-neutral-900":
+        Astro.props.active,
     }
   )}
 >
   {
     Astro.props.src ? (
       <Image
-        class={clsx("relative h-full w-full object-contain", {
-          "transition duration-300 ease-in-out group-hover:scale-105":
+        class={clsx("relative h-full w-full object-cover", {
+          "transition-transform duration-700 ease-out group-hover:scale-[1.03]":
             Astro.props.isInteractive ?? true,
         })}
         {...Astro.props}

--- a/astro/commerce/src/components/hero.astro
+++ b/astro/commerce/src/components/hero.astro
@@ -1,0 +1,73 @@
+---
+import { Image } from "astro:assets";
+import { getProducts } from "../lib/wix";
+
+const products = await getProducts({});
+const heroProduct = products[0];
+---
+
+<section
+  class="relative w-full overflow-hidden bg-neutral-900 text-white"
+>
+  <div class="relative h-[80svh] min-h-[560px] w-full">
+    {
+      heroProduct?.featuredImage?.url ? (
+        <Image
+          src={heroProduct.featuredImage.url}
+          alt=""
+          inferSize
+          width={1920}
+          height={1200}
+          class="absolute inset-0 h-full w-full scale-105 object-cover"
+          loading="eager"
+        />
+      ) : null
+    }
+    <div
+      class="absolute inset-0 bg-gradient-to-t from-black/75 via-black/20 to-black/30"
+    >
+    </div>
+    <div
+      class="relative z-10 mx-auto flex h-full w-full max-w-(--breakpoint-2xl) flex-col justify-end px-4 pb-14 md:pb-20"
+    >
+      <p class="eyebrow mb-4 text-white/75">Spring · Summer 26</p>
+      <h1
+        class="font-display max-w-3xl text-5xl font-medium leading-[0.95] tracking-tight md:text-7xl lg:text-8xl"
+      >
+        Wear the everyday,<br /><em class="italic">beautifully.</em>
+      </h1>
+      <p
+        class="mt-5 max-w-md text-base text-white/80 md:text-lg"
+      >
+        Quietly considered pieces, made for now and the years after.
+      </p>
+      <div class="mt-8 flex items-center gap-3">
+        <a
+          href="/search"
+          class="group inline-flex items-center gap-2 rounded-full bg-white px-7 py-3 text-sm font-medium text-black transition hover:bg-neutral-200"
+        >
+          Shop the edit
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.75"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            class="h-4 w-4 transition group-hover:translate-x-1"
+          >
+            <path d="M5 12h14" />
+            <path d="m12 5 7 7-7 7" />
+          </svg>
+        </a>
+        <a
+          href="/search"
+          class="inline-flex items-center rounded-full border border-white/40 px-7 py-3 text-sm font-medium text-white transition hover:bg-white/10"
+        >
+          Browse all
+        </a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/astro/commerce/src/components/icons/logo.astro
+++ b/astro/commerce/src/components/icons/logo.astro
@@ -8,10 +8,11 @@ type Props = {
 <svg
   xmlns="http://www.w3.org/2000/svg"
   aria-label={`${import.meta.env.SITE_NAME} logo`}
-  viewBox="0 0 32 28"
+  viewBox="0 0 32 32"
   class={clsx("h-4 w-4 fill-black dark:fill-white", Astro.props.class)}
   {...Astro.props}
 >
-  <path d="M21.5758 9.75769L16 0L0 28H11.6255L21.5758 9.75769Z"></path>
-  <path d="M26.2381 17.9167L20.7382 28H32L26.2381 17.9167Z"></path>
+  <path
+    d="M16 2L2 9v14l14 7 14-7V9L16 2zm0 3.3L26.5 10 16 14.7 5.5 10 16 5.3zM5 12l10 4.5V28L5 23V12zm12 16V16.5L27 12v11l-10 5z"
+  ></path>
 </svg>

--- a/astro/commerce/src/components/label.astro
+++ b/astro/commerce/src/components/label.astro
@@ -14,23 +14,31 @@ const position = Astro.props.position || "bottom";
 
 <div
   class={clsx(
-    "absolute bottom-0 left-0 flex w-full px-4 pb-4 @container/label",
+    "absolute bottom-0 left-0 z-10 flex w-full items-end justify-between gap-3 bg-gradient-to-t from-black/55 via-black/25 to-transparent px-5 pb-5 pt-16 text-white",
     {
-      "lg:px-20 lg:pb-[35%]": position === "center",
+      "lg:px-10 lg:pb-12 lg:pt-32": position === "center",
     }
   )}
 >
-  <div
-    class="flex items-center rounded-full border bg-white/70 p-1 text-xs font-semibold text-black backdrop-blur-md dark:border-neutral-800 dark:bg-black/70 dark:text-white"
+  <h3
+    class={clsx(
+      "line-clamp-2 grow leading-snug tracking-tight",
+      position === "center"
+        ? "text-2xl font-semibold lg:text-4xl"
+        : "text-base font-medium",
+    )}
   >
-    <h3 class="mr-4 line-clamp-2 grow pl-2 leading-none tracking-tight">
-      {Astro.props.title}
-    </h3>
-    <Price
-      class="flex-none rounded-full bg-blue-600 p-2 text-white"
-      amount={Astro.props.amount}
-      currencyCode={Astro.props.currencyCode}
-      currencyCodeClass="hidden @[275px]/label:inline"
-    />
-  </div>
+    {Astro.props.title}
+  </h3>
+  <Price
+    class={clsx(
+      "flex-none tabular-nums",
+      position === "center"
+        ? "text-lg font-medium lg:text-xl"
+        : "text-sm font-medium",
+    )}
+    amount={Astro.props.amount}
+    currencyCode={Astro.props.currencyCode}
+    currencyCodeClass="ml-1 text-xs font-normal opacity-70"
+  />
 </div>

--- a/astro/commerce/src/components/layout/footer.astro
+++ b/astro/commerce/src/components/layout/footer.astro
@@ -5,9 +5,10 @@ import FooterMenu from "./footer-menu.astro";
 
 const { COMPANY_NAME, SITE_NAME } = import.meta.env;
 const currentYear = new Date().getFullYear();
-const copyrightDate = 2023 + (currentYear > 2023 ? `-${currentYear}` : "");
-const menu = await getMenu("next-js-frontend-footer-menu");
 const copyrightName = COMPANY_NAME || SITE_NAME || "";
+const copyrightSuffix =
+  copyrightName.length && !copyrightName.endsWith(".") ? "." : "";
+const menu = await getMenu("next-js-frontend-footer-menu");
 ---
 
 <footer class="text-sm text-neutral-500 dark:text-neutral-400">
@@ -24,40 +25,14 @@ const copyrightName = COMPANY_NAME || SITE_NAME || "";
       </a>
     </div>
     <FooterMenu menu={menu} />
-    <div class="md:ml-auto">
-      <a
-        class="flex h-8 w-max flex-none items-center justify-center rounded-md border border-neutral-200 bg-white text-xs text-black dark:border-neutral-700 dark:bg-black dark:text-white"
-        aria-label="Deploy on Vercel"
-        href="https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fwix%2Fnextjs-commerce&env=COMPANY_NAME,WIX_CLIENT_ID,SITE_NAME,TWITTER_CREATOR,TWITTER_SITE&envDescription=Supply%20the%20Wix%20Client%20ID%20for%20your%20Wix%20Store.&envLink=https%3A%2F%2Fdev.wix.com%2Fdocs%2Fgo-headless%2Fgetting-started%2Fsetup%2Fauthorization%2Fcreate-an-o-auth-app-for-visitors-and-members&demo-title=Wix%20Store%20Demo&demo-description=A%20NextJS%20Commerce%20site%20working%20with%20Wix%20Stores&demo-url=https%3A%2F%2Fwix-nextjs-commerce.vercel.app%2F&demo-image=https%3A%2F%2Fstatic.wixstatic.com%2Fmedia%2F8dfd06_e9c49cd22b95454daac5e46a92bbad79~mv2.png"
-      >
-        <span class="px-3">▲</span>
-        <hr
-          class="h-full border-r border-neutral-200 dark:border-neutral-700"
-        />
-        <span class="px-3">Deploy</span>
-      </a>
-    </div>
   </div>
   <div class="border-t border-neutral-200 py-6 text-sm dark:border-neutral-700">
     <div
-      class="mx-auto flex w-full max-w-7xl flex-col items-center gap-1 px-4 md:flex-row md:gap-0 md:px-4 min-[1320px]:px-0"
+      class="mx-auto w-full max-w-7xl px-4 text-center md:px-4 min-[1320px]:px-0"
     >
       <p>
-        &copy; {copyrightDate}
-        {copyrightName}
-        {copyrightName.length && !copyrightName.endsWith(".") ? "." : ""} All rights
-        reserved.
-      </p>
-      <hr
-        class="mx-4 hidden h-4 w-px border-l border-neutral-400 md:inline-block"
-      />
-      <p>
-        <a href="https://github.com/vercel/commerce">View the source</a>
-      </p>
-      <p class="md:ml-auto">
-        <a href="https://vercel.com" class="text-black dark:text-white">
-          Created by ▲ Vercel
-        </a>
+        &copy; {currentYear}
+        {copyrightName}{copyrightSuffix} All rights reserved.
       </p>
     </div>
   </div>

--- a/astro/commerce/src/components/layout/layout.astro
+++ b/astro/commerce/src/components/layout/layout.astro
@@ -1,5 +1,6 @@
 ---
 import { ClientRouter } from "astro:transitions";
+import Marquee from "../marquee.astro";
 import Navbar from "./navbar/index.astro";
 import "../../styles/global.css";
 ---
@@ -9,6 +10,12 @@ import "../../styles/global.css";
     <meta charset="utf-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,300..700&display=swap"
+    />
     <slot name="seo-tags" />
     <ClientRouter />
   </head>
@@ -16,6 +23,7 @@ import "../../styles/global.css";
     class="bg-neutral-50 text-black selection:bg-teal-300 dark:bg-neutral-900 dark:text-white dark:selection:bg-pink-500 dark:selection:text-white"
   >
     <Navbar />
+    <Marquee />
     <main>
       <slot />
     </main>

--- a/astro/commerce/src/components/layout/navbar/index.astro
+++ b/astro/commerce/src/components/layout/navbar/index.astro
@@ -1,12 +1,14 @@
 ---
-import { getMenu } from "../../../lib/wix";
+import { getCollections } from "../../../lib/wix";
 import type { Menu } from "../../../lib/wix/types";
 import CartModal from "../../cart/cart-modal.astro";
 import LogoSquare from "../../logo-square.astro";
 import MobileMenu from "./mobile-menu.astro";
 import Search from "./search.astro";
 
-const menu = await getMenu("next-js-frontend-header-menu");
+// Drive navbar links from real store categories (each Collection has `path` and `title`).
+const collections = await getCollections();
+const menu: Menu[] = collections.map((c) => ({ title: c.title, path: c.path }));
 
 const { SITE_NAME } = import.meta.env;
 ---

--- a/astro/commerce/src/components/layout/search/filter/filter-list.astro
+++ b/astro/commerce/src/components/layout/search/filter/filter-list.astro
@@ -9,12 +9,12 @@ type Props = { list: ListItem[]; title?: string };
 <nav>
   {
     Astro.props.title ? (
-      <h3 class="hidden text-xs text-neutral-500 md:block dark:text-neutral-400">
+      <h3 class="eyebrow hidden pb-3 text-neutral-500 md:block dark:text-neutral-400">
         {Astro.props.title}
       </h3>
     ) : null
   }
-  <ul class="hidden md:block">
+  <ul class="hidden flex-col gap-1 md:flex">
     <FilterItemList list={Astro.props.list} />
   </ul>
   <ul class="md:hidden">

--- a/astro/commerce/src/components/layout/search/filter/path-filter-item.astro
+++ b/astro/commerce/src/components/layout/search/filter/path-filter-item.astro
@@ -12,16 +12,24 @@ const DynamicTag = active ? "p" : "a";
 newParams.delete("q");
 ---
 
-<li class="mt-2 flex text-black dark:text-white">
+<li>
   <DynamicTag
     href={createUrl(Astro.props.item.path, newParams)}
     class={clsx(
-      "w-full text-sm underline-offset-4 hover:underline dark:hover:text-neutral-100",
-      {
-        "underline underline-offset-4": active,
-      }
+      "group relative flex items-center gap-2 py-1.5 text-sm capitalize transition-colors",
+      active
+        ? "font-medium text-black dark:text-white"
+        : "text-neutral-500 hover:text-black dark:text-neutral-400 dark:hover:text-white",
     )}
   >
-    {Astro.props.item.title}
+    <span
+      class={clsx(
+        "h-1 w-1 flex-none rounded-full transition-all",
+        active
+          ? "bg-black dark:bg-white"
+          : "bg-transparent group-hover:bg-neutral-300 dark:group-hover:bg-neutral-600",
+      )}
+      aria-hidden="true"></span>
+    <span>{Astro.props.item.title}</span>
   </DynamicTag>
 </li>

--- a/astro/commerce/src/components/layout/search/filter/sort-filter-item.astro
+++ b/astro/commerce/src/components/layout/search/filter/sort-filter-item.astro
@@ -19,14 +19,25 @@ const href = createUrl(
 const DynamicTag = active ? "p" : "a";
 ---
 
-<li class="mt-2 flex text-sm text-black dark:text-white">
+<li>
   <DynamicTag
     data-astro-prefetch={!active ? false : undefined}
     href={href}
-    class={clsx("w-full hover:underline hover:underline-offset-4", {
-      "underline underline-offset-4": active,
-    })}
+    class={clsx(
+      "group relative flex items-center gap-2 py-1.5 text-sm transition-colors",
+      active
+        ? "font-medium text-black dark:text-white"
+        : "text-neutral-500 hover:text-black dark:text-neutral-400 dark:hover:text-white",
+    )}
   >
-    {Astro.props.item.title}
+    <span
+      class={clsx(
+        "h-1 w-1 flex-none rounded-full transition-all",
+        active
+          ? "bg-black dark:bg-white"
+          : "bg-transparent group-hover:bg-neutral-300 dark:group-hover:bg-neutral-600",
+      )}
+      aria-hidden="true"></span>
+    <span>{Astro.props.item.title}</span>
   </DynamicTag>
 </li>

--- a/astro/commerce/src/components/layout/search/layout.astro
+++ b/astro/commerce/src/components/layout/search/layout.astro
@@ -6,16 +6,20 @@ import FilterList from "./filter/filter-list.astro";
 ---
 
 <div
-  class="mx-auto flex max-w-(--breakpoint-2xl) flex-col gap-8 px-4 pb-4 text-black md:flex-row dark:text-white"
+  class="mx-auto flex max-w-(--breakpoint-2xl) flex-col gap-10 px-4 pb-16 pt-8 text-black md:flex-row md:gap-12 md:pt-12 dark:text-white"
 >
-  <div class="order-first w-full flex-none md:max-w-[125px]">
+  <aside
+    class="order-first w-full flex-none md:sticky md:top-6 md:max-w-[180px] md:self-start"
+  >
     <Collections />
-  </div>
+  </aside>
   <div class="order-last min-h-screen w-full md:order-none">
     <slot />
   </div>
-  <div class="order-none flex-none md:order-last md:w-[125px]">
+  <aside
+    class="order-none flex-none md:sticky md:top-6 md:order-last md:w-[160px] md:self-start"
+  >
     <FilterList list={sorting} title="Sort by" />
-  </div>
+  </aside>
 </div>
 <Footer />

--- a/astro/commerce/src/components/marquee.astro
+++ b/astro/commerce/src/components/marquee.astro
@@ -1,0 +1,32 @@
+---
+const items = [
+  "Free shipping on orders over $100",
+  "New drops weekly",
+  "Made with sustainable cotton",
+  "Free returns within 30 days",
+];
+---
+
+<div
+  class="overflow-hidden border-y border-neutral-200 bg-white py-2.5 dark:border-neutral-800 dark:bg-black"
+>
+  <div class="flex w-max animate-marquee">
+    {
+      [0, 1].map(() => (
+        <div
+          class="flex shrink-0 items-center gap-12 pr-12 text-[11px] font-medium uppercase tracking-[0.22em] text-neutral-700 dark:text-neutral-300"
+          aria-hidden={false}
+        >
+          {items.map((item) => (
+            <span class="flex items-center gap-12">
+              <span>{item}</span>
+              <span class="opacity-30" aria-hidden="true">
+                ●
+              </span>
+            </span>
+          ))}
+        </div>
+      ))
+    }
+  </div>
+</div>

--- a/astro/commerce/src/pages/index.astro
+++ b/astro/commerce/src/pages/index.astro
@@ -1,11 +1,13 @@
 ---
 import Carousel from "../components/carousel.astro";
 import ThreeItemGrid from "../components/grid/three-items.astro";
+import Hero from "../components/hero.astro";
 import Footer from "../components/layout/footer.astro";
 import RootLayout from "../components/layout/layout.astro";
 ---
 
 <RootLayout>
+  <Hero />
   <ThreeItemGrid />
   <Carousel />
   <Footer />

--- a/astro/commerce/src/styles/global.css
+++ b/astro/commerce/src/styles/global.css
@@ -1,5 +1,20 @@
 @import "tailwindcss";
 
+@theme {
+  --font-display:
+    "Fraunces", ui-serif, Georgia, "Times New Roman", serif;
+  --animate-marquee: marquee 40s linear infinite;
+}
+
+@keyframes marquee {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+
 @media (prefers-color-scheme: dark) {
   html {
     color-scheme: dark;
@@ -12,6 +27,20 @@
   }
 }
 
+html {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+body {
+  font-feature-settings: "ss01", "cv11";
+}
+
+.tabular-nums {
+  font-variant-numeric: tabular-nums;
+}
+
 a,
 button {
   cursor: pointer;
@@ -21,13 +50,21 @@ a:focus-visible,
 input:focus-visible,
 button:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 2px rgb(163 163 163 / 1), 0 0 0 4px rgb(250 250 250 / 1);
+  box-shadow: 0 0 0 2px rgb(23 23 23 / 1), 0 0 0 4px rgb(250 250 250 / 1);
 }
 
 @media (prefers-color-scheme: dark) {
   a:focus-visible,
   input:focus-visible,
   button:focus-visible {
-    box-shadow: 0 0 0 2px rgb(82 82 82 / 1), 0 0 0 4px rgb(23 23 23 / 1);
+    box-shadow: 0 0 0 2px rgb(250 250 250 / 1), 0 0 0 4px rgb(23 23 23 / 1);
   }
+}
+
+/* Editorial section eyebrow */
+.eyebrow {
+  font-size: 0.6875rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-weight: 500;
 }


### PR DESCRIPTION
## Summary
- Adds the `@astrojs/react` integration along with `react`/`react-dom` so the template can host React components.
- Introduces new `Hero` and `Marquee` components; the home page now renders the `Hero` above the existing grid and carousel.
- Refactors existing template components (carousel, grid items, tile, label, footer, layout, navbar, search filter list / path-filter / sort-filter / search layout) and updates the global stylesheet.
- Bumps `engines.node` to `24.x` for `astro/commerce`.

## Notes
- This PR is scoped to `astro/commerce/` only. Other working-tree changes in the repo (yarn migration artifacts, alphabetical reorderings in sibling templates, root `package-lock.json` churn) were intentionally left out and will be handled separately.
- `package-lock.json` is **not** updated in this PR because the root lockfile is currently entangled with an in-progress yarn migration. Please regenerate it cleanly (or pick it up in the migration PR) before merging.

## Test plan
- [ ] `npm install` at repo root resolves cleanly with the new `@astrojs/react` / `react` / `react-dom` dependencies.
- [ ] `cd astro/commerce && npm run dev` — home page renders Hero, ThreeItemGrid, Carousel, Marquee section, Footer.
- [ ] `cd astro/commerce && npm run build` succeeds.
- [ ] Search filters (path, sort) and the layout still work end-to-end on the catalog/search pages.
- [ ] Visual check on cart, navbar, and footer for regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)