### PR TITLE
Fix Vite security origin mismatch

### DIFF
--- a/astro/blank/astro.config.mjs
+++ b/astro/blank/astro.config.mjs
@@ -6,4 +6,5 @@ import wixPages from "@wix/astro-pages";
 // https://astro.build/config
 export default defineConfig({
   integrations: [wix(), wixPages()],
+  security: { checkOrigin: false },
 });

--- a/astro/commerce/astro.config.mjs
+++ b/astro/commerce/astro.config.mjs
@@ -10,7 +10,6 @@ import tailwindcss from "@tailwindcss/vite";
 export default defineConfig({
   output: "server",
   integrations: [wix(), wixPages(), react()],
-  // Disable — TLS terminates at Wix's edge so Origin/url.origin mismatch (https vs http).
   security: { checkOrigin: false },
   image: {
     domains: ["static.wixstatic.com"],

--- a/astro/registration/astro.config.mjs
+++ b/astro/registration/astro.config.mjs
@@ -7,6 +7,7 @@ import tailwindcss from "@tailwindcss/vite";
 // https://astro.build/config
 export default defineConfig({
   integrations: [wix(), wixPages()],
+  security: { checkOrigin: false },
   vite: {
     plugins: [tailwindcss()],
   },

--- a/astro/scheduler/astro.config.mjs
+++ b/astro/scheduler/astro.config.mjs
@@ -7,6 +7,7 @@ import tailwindcss from "@tailwindcss/vite";
 // https://astro.build/config
 export default defineConfig({
   integrations: [wix(), wixPages()],
+  security: { checkOrigin: false },
   vite: {
     plugins: [tailwindcss()],
   },


### PR DESCRIPTION
LS terminates at Wix's edge so Origin/url.origin mismatch (https vs http).