### PR TITLE
chore(astro): bump @wix/astro-pages to ^2.0.4

### DIFF
--- a/astro/blank/package.json
+++ b/astro/blank/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@wix/astro": "^2.13.0",
-    "@wix/astro-pages": "^2.0.3",
+    "@wix/astro-pages": "^2.0.4",
     "@wix/dashboard": "^1.3.36",
     "@wix/essentials": "^1.0.6",
     "@wix/sdk": "^1.21.5",

--- a/astro/commerce/package.json
+++ b/astro/commerce/package.json
@@ -11,7 +11,7 @@
     "@astrojs/react": "^5.0.4",
     "@tailwindcss/vite": "^4.1.7",
     "@wix/astro": "^2.13.0",
-    "@wix/astro-pages": "^2.0.3",
+    "@wix/astro-pages": "^2.0.4",
     "@wix/categories": "^1.0.183",
     "@wix/dashboard": "^1.3.36",
     "@wix/data": "1.0.168",

--- a/astro/registration/package.json
+++ b/astro/registration/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.1.7",
     "@wix/astro": "^2.13.0",
-    "@wix/astro-pages": "^2.0.3",
+    "@wix/astro-pages": "^2.0.4",
     "@wix/dashboard": "^1.3.36",
     "@wix/essentials": "^1.0.6",
     "@wix/forms": "^1.0.259",

--- a/astro/scheduler/package.json
+++ b/astro/scheduler/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.1.7",
     "@wix/astro": "^2.13.0",
-    "@wix/astro-pages": "^2.0.3",
+    "@wix/astro-pages": "^2.0.4",
     "@wix/bookings": "^1.0.667",
     "@wix/dashboard": "^1.3.36",
     "@wix/ecom": "^1.0.1044",


### PR DESCRIPTION
## What

Bumps `@wix/astro-pages` from `^2.0.3` → `^2.0.4` in 4 Astro templates:

- `astro/commerce`
- `astro/blank`
- `astro/scheduler`
- `astro/registration` (the `@wix/forms`-based template)

## Why this is a version bump, not a refactor

I diffed the published `2.0.3` and `2.0.4` packages. **2.0.4 is a pure internal build refactor** — the public surface is identical:

| | 2.0.3 | 2.0.4 |
|---|---|---|
| Default export | `createIntegration` | identical signature |
| Types | `Page`, `PageMetadata` | identical |
| Virtual module | `wix:astro:pages` | identical |
| Injected route | `/_wix/pages.json` | identical |
| Peer deps | `astro ^5.0.0` | unchanged |
| Build | tsup → `build/index.js` | tsdown/rolldown → `build/integration/index.mjs` + `backend-runtime/` |

So the existing `astro.config.mjs` (`wixPages()`) and `env.d.ts` (`import type { PageMetadata }`) usages keep working with **no code changes**.

## Notes

- ⚠️ `package-lock.json` is **not** updated in this PR — run `npm install` to sync the lockfile before merge.
- The other 5 astro templates (`media-manager`, `blog`, `cms`, `hello`, `store`) remain on `^2.0.3`; can be bumped in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)