### PR TITLE
headless-blank: scaffold parity — wix scripts, .env.local ignore

### DIFF
--- a/astro/headless-blank/.gitignore
+++ b/astro/headless-blank/.gitignore
@@ -18,6 +18,8 @@ pnpm-debug.log*
 
 # environment variables
 .env
+.env.local
+.env.*.local
 .env.production
 
 # macOS-specific files

--- a/astro/headless-blank/package.json
+++ b/astro/headless-blank/package.json
@@ -7,7 +7,11 @@
     "dev": "wix dev",
     "build": "wix build",
     "preview": "wix preview",
-    "release": "wix release"
+    "release": "wix release",
+    "wix": "wix",
+    "generate": "wix generate",
+    "env": "wix env",
+    "skills": "wix skills"
   },
   "dependencies": {
     "@wix/astro": "^2.13.0",
@@ -16,16 +20,16 @@
     "@wix/essentials": "^1.0.6",
     "@wix/sdk": "^1.21.5",
     "astro": "^5.8.0",
-    "typescript": "^5.8.3",
-    "@astrojs/react": "4.3.0",
-    "react": "^18.3.0",
-    "react-dom": "^18.3.0",
-    "@wix/cloud-provider-fetch-adapter": "^1.0.4"
+    "typescript": "^5.8.3"
   },
   "devDependencies": {
     "@astrojs/cloudflare": "12.5.5",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
-    "@wix/cli": "^1.1.206"
+    "@wix/cli": "^1.1.206",
+    "@astrojs/react": "4.3.0",
+    "@wix/cloud-provider-fetch-adapter": "^1.0.4",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0"
   }
 }


### PR DESCRIPTION
## What

Follow-up to #678 (replaces #679, which was auto-closed during a branch rewrite). Diffing `astro/headless-blank` against a real `npm create @wix/new headless` scaffold surfaced these parity gaps:

| Gap | Fix |
|---|---|
| `scripts` missing `wix`, `generate`, `env`, `skills` | Added — `npm run skills` etc. now work in generated projects |
| **`.gitignore` doesn't cover `.env.local`** | Added `.env.local` + `.env.*.local`. `wix env pull` writes `WIX_CLIENT_SECRET` into `.env.local`; without this a generated project can commit its secret. ⚠️ This gap is inherited from `astro/blank`, which has the same issue. |
| react/adapter deps in `dependencies` | Moved to `devDependencies`, where the scaffold keeps them |

(`astro.config.mjs` is deliberately left at Astro defaults for the dev toolbar — dev-only UI preference with no production effect, so not worth diverging from defaults.)

## Why

The template exists for programmatic consumption (degit into a project bound to an existing site), so generated projects should behave exactly like CLI-scaffolded ones — same npm scripts, same secret hygiene.

The `.gitignore` fix is the important one: it's a secret-leak guard. Note `astro/blank` has the same `.env.local` gap — happy to fix it there too if you want it in this PR.
