### PR TITLE
feat(astro): add rentals booking template

### DIFF
--- a/astro/rentals/.env.example
+++ b/astro/rentals/.env.example
@@ -1,0 +1,8 @@
+# Required: your Wix Headless OAuth app Client ID (public, non-secret).
+# Create a Headless OAuth app in your Wix site's dashboard
+# (Settings > Headless) and copy its Client ID here.
+PUBLIC_WIX_CLIENT_ID=
+
+# Optional: restrict the catalog to a single Bookings app by its appId.
+# Leave empty to list every non-hidden Bookings service on the site.
+PUBLIC_WIX_RENTALS_APP_ID=

--- a/astro/rentals/.gitignore
+++ b/astro/rentals/.gitignore
@@ -1,0 +1,29 @@
+# wix integration
+.wix/
+
+# build output
+dist/
+
+# generated types
+.astro/
+
+# dependencies
+node_modules/
+
+# logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# environment variables
+.env
+.env.production
+.env.local
+.env*.local
+
+# macOS-specific files
+.DS_Store
+
+# jetbrains setting folder
+.idea/

--- a/astro/rentals/README.md
+++ b/astro/rentals/README.md
@@ -1,0 +1,77 @@
+# Wix Astro Rentals Template
+
+A headless space-rentals + booking storefront built with [Astro](https://astro.build), React, and the [Wix SDK](https://dev.wix.com/docs/sdk). Browse rentable spaces, pick a date/time (by the hour or by the day), and check out through Wix's hosted checkout. Members can sign in to see and manage their bookings.
+
+> Our Astro templates are still in development and subject to change.
+
+## Features
+
+- **Browse & filter** rentable spaces backed by Wix Bookings services
+- **Hourly and daily** reservations with a live availability calendar
+- **Hosted checkout** via the Wix eCom checkout redirect (no card handling in-app)
+- **Member area** — sign in with Wix Headless OAuth to view, cancel, and reschedule bookings
+- **Anonymous browsing** — a visitor session is created automatically; login is only needed for the account area
+
+## Tech stack
+
+Astro 5 (server output) · React 18 + react-router · Tailwind CSS v4 · `@wix/astro`, `@wix/sdk`, `@wix/bookings`, `@wix/ecom`, `@wix/members`, `@wix/redirects`.
+
+## Getting started
+
+### Prerequisites
+
+- Node.js 18+
+- A Wix site with the **Bookings** app installed and at least one bookable service
+- A **Headless OAuth** app on that site (dashboard → Settings → Headless) — copy its **Client ID**
+
+### Setup
+
+```bash
+npm install
+cp .env.example .env
+# edit .env and set PUBLIC_WIX_CLIENT_ID to your Headless OAuth Client ID
+```
+
+Whitelist `http://localhost:4321/login-callback` (and your production equivalent) as an allowed redirect URI in the Headless OAuth app settings, so member login can return to the app.
+
+### Run
+
+```bash
+npm run dev      # dev server at http://localhost:4321
+npm run build    # production build
+```
+
+## Environment variables
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `PUBLIC_WIX_CLIENT_ID` | yes | Your Headless OAuth app Client ID (public, non-secret). |
+| `PUBLIC_WIX_RENTALS_APP_ID` | no | Restrict the catalog to a single Bookings app by its `appId`. When unset, all non-hidden services are listed. |
+
+## Project structure
+
+```
+src/
+├── pages/            # Astro entry (index + catch-all) that mount the React app
+├── App.tsx           # react-router routes (/, /rental/:slug, /confirmation, /account, /login-callback)
+├── views/            # Page-level React views (RentalsList, RentalDetail, Account, …)
+├── components/       # Reusable UI (Navbar, ReservationPanel, icons, ui primitives, …)
+├── lib/
+│   ├── wix-client.ts # Wix SDK client + OAuth/session helpers
+│   ├── rentals.ts    # Services, availability, booking + checkout, member bookings
+│   ├── auth.tsx      # Auth React context
+│   ├── format.ts     # Formatting + Wix media helpers
+│   └── types.ts
+├── layouts/          # Astro layout
+└── styles/           # Tailwind theme + global CSS
+```
+
+## Known limitation
+
+The member **My bookings** list can currently come back empty even when a booking is correctly attached to the member in the dashboard. The checkout already stamps the member's `contactId` and buyer email onto the booking/checkout; the read-side scoping is still under investigation.
+
+## Need help?
+
+- [Wix Headless Documentation](https://dev.wix.com/docs/go-headless)
+- [Wix SDK Documentation](https://dev.wix.com/docs/sdk)
+- [Community on Discord](https://discord.gg/n6TBrSnYTp)

--- a/astro/rentals/astro.config.mjs
+++ b/astro/rentals/astro.config.mjs
@@ -1,0 +1,26 @@
+// @ts-check
+import { defineConfig } from 'astro/config';
+import wix from "@wix/astro";
+import wixPages from "@wix/astro-pages";
+
+import react from "@astrojs/react";
+import tailwindcss from "@tailwindcss/vite";
+import cloudProviderFetchAdapter from "@wix/cloud-provider-fetch-adapter";
+const isBuild = process.env.NODE_ENV == "production";
+
+// https://astro.build/config
+export default defineConfig({
+  integrations: [wix(), wixPages(), react()],
+  security: { checkOrigin: false },
+  ...(isBuild && { adapter: cloudProviderFetchAdapter({}) }),
+
+  image: {
+    domains: ["static.wixstatic.com"],
+  },
+
+  vite: {
+    plugins: [tailwindcss()],
+  },
+
+  output: "server",
+});

--- a/astro/rentals/package.json
+++ b/astro/rentals/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "wix-astro-rentals",
+  "type": "module",
+  "version": "0.0.1",
+  "scripts": {
+    "astro": "astro",
+    "dev": "wix dev",
+    "build": "wix build",
+    "wix": "wix",
+    "preview": "wix preview",
+    "release": "wix release",
+    "generate": "wix generate",
+    "env": "wix env",
+    "skills": "wix skills"
+  },
+  "dependencies": {
+    "@tailwindcss/vite": "^4.3.1",
+    "@wix/astro": "^2.13.0",
+    "@wix/astro-pages": "^2.0.4",
+    "@wix/bookings": "1.0.1519",
+    "@wix/dashboard": "^1.3.36",
+    "@wix/ecom": "1.0.2252",
+    "@wix/essentials": "^1.0.6",
+    "@wix/members": "^1.0.485",
+    "@wix/redirects": "1.0.118",
+    "@wix/sdk": "^1.21.5",
+    "astro": "^5.8.0",
+    "react-router-dom": "^7.18.0",
+    "tailwindcss": "^4.3.1",
+    "typescript": "^5.8.3"
+  },
+  "devDependencies": {
+    "@astrojs/react": "^4.3.0",
+    "@types/react": "^18.3.1",
+    "@types/react-dom": "^18.3.1",
+    "@wix/cli": "^1.1.92",
+    "@wix/cloud-provider-fetch-adapter": "^1.0.0",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  }
+}

--- a/astro/rentals/src/App.tsx
+++ b/astro/rentals/src/App.tsx
@@ -1,0 +1,55 @@
+import { BrowserRouter, Link, Route, Routes, useLocation } from 'react-router-dom';
+import { Navbar } from './components/Navbar';
+import { Footer } from './components/Footer';
+import { ConfigBanner } from './components/ui';
+import { AuthProvider } from './lib/auth';
+import { RentalsList } from './views/RentalsList';
+import { RentalDetail } from './views/RentalDetail';
+import { Confirmation } from './views/Confirmation';
+import { Account } from './views/Account';
+import { LoginCallback } from './views/LoginCallback';
+import { isClientConfigured } from './lib/wix-client';
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <AuthProvider>
+        <Shell />
+      </AuthProvider>
+    </BrowserRouter>
+  );
+}
+
+function Shell() {
+  const { pathname } = useLocation();
+  const isDetail = pathname.startsWith('/rental/');
+  return (
+    <div className="flex min-h-screen flex-col bg-cream text-ink">
+      {!isDetail && <Navbar />}
+      {!isClientConfigured && <ConfigBanner />}
+      <main className="flex-1">
+        <Routes>
+          <Route path="/" element={<RentalsList />} />
+          <Route path="/rental/:slug" element={<RentalDetail />} />
+          <Route path="/confirmation" element={<Confirmation />} />
+          <Route path="/account" element={<Account />} />
+          <Route path="/login-callback" element={<LoginCallback />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </main>
+      <Footer />
+    </div>
+  );
+}
+
+function NotFound() {
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-24 text-center">
+      <h1 className="text-2xl font-semibold tracking-tight text-ink">Page not found</h1>
+      <p className="mt-2 text-muted">The page you’re looking for doesn’t exist.</p>
+      <Link to="/" className="mt-4 inline-block font-medium text-accent hover:text-accent-hover">
+        ← Back to spaces
+      </Link>
+    </div>
+  );
+}

--- a/astro/rentals/src/components/DateRangeSearch.tsx
+++ b/astro/rentals/src/components/DateRangeSearch.tsx
@@ -1,0 +1,217 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  CalendarIcon,
+  ChevronDownIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  SearchIcon,
+} from './icons';
+
+const WEEKDAYS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+const MONTHS = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+const pad = (n: number) => String(n).padStart(2, '0');
+const ymd = (d: Date) => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+const parseYmd = (s: string) => {
+  const [y, m, d] = s.split('-').map(Number);
+  return new Date(y, m - 1, d);
+};
+const nice = (s: string) =>
+  parseYmd(s).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+
+export interface DateRange {
+  start: string;
+  end: string;
+}
+
+export function DateRangeSearch({
+  onApply,
+  initial,
+}: {
+  onApply: (range: DateRange | null) => void;
+  initial?: DateRange | null;
+}) {
+  const today = useMemo(() => {
+    const d = new Date();
+    d.setHours(0, 0, 0, 0);
+    return d;
+  }, []);
+  const [open, setOpen] = useState(false);
+  const [viewYear, setViewYear] = useState(today.getFullYear());
+  const [viewMonth, setViewMonth] = useState(today.getMonth());
+  const [start, setStart] = useState<string | null>(initial?.start ?? null);
+  const [end, setEnd] = useState<string | null>(initial?.end ?? null);
+  const [applied, setApplied] = useState<DateRange | null>(initial ?? null);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onDoc);
+    return () => document.removeEventListener('mousedown', onDoc);
+  }, [open]);
+
+  const pick = (key: string) => {
+    if (!start || (start && end)) {
+      setStart(key);
+      setEnd(null);
+    } else if (key >= start) {
+      setEnd(key);
+    } else {
+      setStart(key);
+      setEnd(null);
+    }
+  };
+
+  const canPrev =
+    viewYear > today.getFullYear() ||
+    (viewYear === today.getFullYear() && viewMonth > today.getMonth());
+  const shift = (delta: number) => {
+    if (delta < 0 && !canPrev) return;
+    const d = new Date(viewYear, viewMonth + delta, 1);
+    setViewYear(d.getFullYear());
+    setViewMonth(d.getMonth());
+  };
+
+  const apply = () => {
+    if (start) {
+      const r = { start, end: end ?? start };
+      setApplied(r);
+      onApply(r);
+    }
+    setOpen(false);
+  };
+  const clear = () => {
+    setStart(null);
+    setEnd(null);
+    setApplied(null);
+    onApply(null);
+  };
+
+  const label = applied
+    ? applied.start === applied.end
+      ? nice(applied.start)
+      : `${nice(applied.start)} – ${nice(applied.end)}`
+    : 'Select dates';
+
+  const renderMonth = (year: number, month: number) => {
+    const first = new Date(year, month, 1);
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+    const cells: (Date | null)[] = [];
+    for (let i = 0; i < first.getDay(); i++) cells.push(null);
+    for (let d = 1; d <= daysInMonth; d++) cells.push(new Date(year, month, d));
+    return (
+      <div className="grid grid-cols-7 gap-1 text-center text-xs text-muted">
+        {WEEKDAYS.map((w) => (
+          <div key={w} className="py-1">{w}</div>
+        ))}
+        {cells.map((date, i) => {
+          if (!date) return <div key={`e${i}`} />;
+          const key = ymd(date);
+          const past = date < today;
+          const isEdge = key === start || key === end;
+          const within = start && end && key > start && key < end;
+          return (
+            <button
+              key={key}
+              type="button"
+              disabled={past}
+              onClick={() => pick(key)}
+              className={`aspect-square rounded-lg text-sm transition-colors ${
+                isEdge
+                  ? 'bg-ink font-semibold text-white'
+                  : within
+                    ? 'bg-accent-soft text-ink'
+                    : past
+                      ? 'cursor-not-allowed text-muted/40'
+                      : 'text-ink hover:bg-cream'
+              }`}
+            >
+              {date.getDate()}
+            </button>
+          );
+        })}
+      </div>
+    );
+  };
+
+  const next = new Date(viewYear, viewMonth + 1, 1);
+
+  return (
+    <div ref={ref} className="relative w-full max-w-md">
+      <div className="flex overflow-hidden rounded-xl border border-line bg-surface shadow-sm transition-colors focus-within:border-accent">
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className="flex flex-1 items-center gap-2.5 px-4 py-3 text-left text-sm"
+        >
+          <CalendarIcon size={18} className="shrink-0 text-muted" />
+          <span className={applied ? 'text-ink' : 'text-muted'}>{label}</span>
+          <ChevronDownIcon
+            size={16}
+            className={`ml-auto text-muted transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
+          />
+        </button>
+        <button
+          type="button"
+          onClick={() => (open ? apply() : setOpen(true))}
+          className="flex items-center justify-center bg-accent px-4 text-white transition-colors hover:bg-accent-hover"
+          aria-label="Search dates"
+        >
+          <SearchIcon size={18} />
+        </button>
+      </div>
+
+      {open && (
+        <div className="absolute left-0 z-40 mt-2 w-[min(680px,calc(100vw-2rem))]">
+          <div className="animate-scale-in rounded-2xl border border-line bg-surface p-5 shadow-xl">
+            <div className="flex items-center justify-between">
+              <button
+                type="button"
+                onClick={() => shift(-1)}
+                disabled={!canPrev}
+                className="rounded-lg p-1.5 text-ink transition-colors enabled:hover:bg-cream disabled:opacity-30"
+                aria-label="Previous month"
+              >
+                <ChevronLeftIcon size={18} />
+              </button>
+              <div className="flex flex-1 justify-around px-4 text-sm font-medium text-ink">
+                <span>{MONTHS[viewMonth]} {viewYear}</span>
+                <span className="hidden sm:inline">{MONTHS[next.getMonth()]} {next.getFullYear()}</span>
+              </div>
+              <button
+                type="button"
+                onClick={() => shift(1)}
+                className="rounded-lg p-1.5 text-ink transition-colors hover:bg-cream"
+                aria-label="Next month"
+              >
+                <ChevronRightIcon size={18} />
+              </button>
+            </div>
+            <div className="mt-3 grid grid-cols-1 gap-6 sm:grid-cols-2">
+              {renderMonth(viewYear, viewMonth)}
+              <div className="hidden sm:block">{renderMonth(next.getFullYear(), next.getMonth())}</div>
+            </div>
+            <div className="mt-4 flex items-center justify-between border-t border-line pt-3">
+              <button type="button" onClick={clear} className="text-sm text-muted transition-colors hover:text-ink">
+                Clear
+              </button>
+              <button
+                type="button"
+                onClick={apply}
+                disabled={!start}
+                className="rounded-lg bg-ink px-5 py-2 text-sm font-medium text-white transition-colors enabled:hover:bg-black disabled:cursor-not-allowed disabled:bg-line disabled:text-muted"
+              >
+                Apply
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/astro/rentals/src/components/DayReservationPanel.tsx
+++ b/astro/rentals/src/components/DayReservationPanel.tsx
@@ -1,0 +1,351 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { getAvailability, reserve } from '../lib/rentals';
+import { formatDurationRange } from '../lib/format';
+import { CalendarIcon, ChevronLeftIcon, ChevronRightIcon } from './icons';
+
+const WEEKDAYS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+const MONTHS = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+const MINUTES_PER_DAY = 24 * 60;
+
+const pad = (n: number) => String(n).padStart(2, '0');
+const ymd = (d: Date) => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+const parseYmd = (s: string) => {
+  const [y, m, d] = s.split('-').map(Number);
+  return new Date(y, m - 1, d);
+};
+const daysBetween = (a: string, b: string) =>
+  Math.round((parseYmd(b).getTime() - parseYmd(a).getTime()) / 86_400_000);
+const niceDate = (s: string) =>
+  parseYmd(s).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+
+interface LocationInfo {
+  name?: string;
+  address?: string;
+}
+
+/** Per-day availability: whether it can start/continue a stay, the raw Wix entry
+ *  (needed to build the booking) and the ISO end of that day's slot. */
+interface DayInfo {
+  bookable: boolean;
+  raw: unknown;
+  endIso: string;
+}
+
+interface Props {
+  serviceId: string;
+  minDays: number;
+  maxDays: number;
+  priceLabel?: string;
+  priceUnit?: string;
+  initialDate?: string;
+  onLocation?: (loc: LocationInfo | null) => void;
+}
+
+export function DayReservationPanel({
+  serviceId,
+  minDays,
+  maxDays,
+  priceLabel,
+  priceUnit,
+  initialDate,
+  onLocation,
+}: Props) {
+  const today = useMemo(() => {
+    const d = new Date();
+    d.setHours(0, 0, 0, 0);
+    return d;
+  }, []);
+  const todayKey = ymd(today);
+  const base = initialDate ? parseYmd(initialDate) : today;
+
+  const [open, setOpen] = useState(false);
+  const [viewYear, setViewYear] = useState(base.getFullYear());
+  const [viewMonth, setViewMonth] = useState(base.getMonth());
+  const [checkIn, setCheckIn] = useState<string | null>(null);
+  const [checkOut, setCheckOut] = useState<string | null>(null);
+  const [dayInfo, setDayInfo] = useState<Map<string, DayInfo>>(new Map());
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [reserving, setReserving] = useState(false);
+  const [reserveError, setReserveError] = useState<string | null>(null);
+  const popRef = useRef<HTMLDivElement>(null);
+  const fetched = useRef<Set<string>>(new Set());
+
+  // Close on outside click.
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (popRef.current && !popRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onDoc);
+    return () => document.removeEventListener('mousedown', onDoc);
+  }, [open]);
+
+  // Load availability for the viewed month (+ a buffer so stays crossing into the
+  // next month can be validated). Results are merged and each month fetched once.
+  useEffect(() => {
+    const key = `${viewYear}-${viewMonth}`;
+    if (fetched.current.has(key)) return;
+    fetched.current.add(key);
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    const from = `${viewYear}-${pad(viewMonth + 1)}-01T00:00:00`;
+    const lastDay = new Date(viewYear, viewMonth + 1, 0).getDate();
+    const end = new Date(viewYear, viewMonth, lastDay + maxDays + 1);
+    const to = `${end.getFullYear()}-${pad(end.getMonth() + 1)}-${pad(end.getDate())}T23:59:59`;
+    getAvailability(serviceId, from, to)
+      .then((res) => {
+        if (cancelled) return;
+        setDayInfo((prev) => {
+          const next = new Map(prev);
+          for (const s of res.slots) {
+            const endIso = (s.raw as { slot?: { endDate?: string } })?.slot?.endDate ?? '';
+            next.set(s.dayKey, { bookable: s.bookable, raw: s.raw, endIso });
+          }
+          return next;
+        });
+        onLocation?.(res.slots[0]?.location ?? null);
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          fetched.current.delete(key); // allow a retry
+          setError(e?.message ?? 'Could not load availability.');
+        }
+      })
+      .finally(() => !cancelled && setLoading(false));
+    return () => {
+      cancelled = true;
+    };
+    // onLocation intentionally omitted to avoid refetch loops
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [serviceId, viewYear, viewMonth, maxDays]);
+
+  const canPrevMonth =
+    viewYear > today.getFullYear() ||
+    (viewYear === today.getFullYear() && viewMonth > today.getMonth());
+  const goMonth = (delta: number) => {
+    const d = new Date(viewYear, viewMonth + delta, 1);
+    setViewYear(d.getFullYear());
+    setViewMonth(d.getMonth());
+  };
+
+  // Every day in [a, b] inclusive is bookable.
+  const spanBookable = (a: string, b: string) => {
+    const start = parseYmd(a);
+    const days = daysBetween(a, b);
+    for (let i = 0; i <= days; i++) {
+      const d = new Date(start);
+      d.setDate(d.getDate() + i);
+      if (!dayInfo.get(ymd(d))?.bookable) return false;
+    }
+    return true;
+  };
+
+  const pickDay = (key: string) => {
+    if (!dayInfo.get(key)?.bookable) return;
+    // Starting fresh, or restarting after a complete range.
+    if (!checkIn || (checkIn && checkOut)) {
+      setCheckIn(key);
+      setCheckOut(null);
+      return;
+    }
+    // Choosing the check-out: must be after check-in, within maxDays, and the
+    // whole span available. Otherwise treat the click as a new check-in.
+    if (key > checkIn && daysBetween(checkIn, key) + 1 <= maxDays && spanBookable(checkIn, key)) {
+      setCheckOut(key);
+    } else {
+      setCheckIn(key);
+      setCheckOut(null);
+    }
+  };
+
+  // Whether a day should be disabled while picking the check-out.
+  const disabledAsEnd = (key: string) =>
+    !!checkIn &&
+    !checkOut &&
+    key > checkIn &&
+    (daysBetween(checkIn, key) + 1 > maxDays || !spanBookable(checkIn, key));
+
+  const monthCells = useMemo(() => {
+    const first = new Date(viewYear, viewMonth, 1);
+    const daysInMonth = new Date(viewYear, viewMonth + 1, 0).getDate();
+    const cells: (Date | null)[] = [];
+    for (let i = 0; i < first.getDay(); i++) cells.push(null);
+    for (let d = 1; d <= daysInMonth; d++) cells.push(new Date(viewYear, viewMonth, d));
+    return cells;
+  }, [viewYear, viewMonth]);
+
+  const start = checkIn;
+  const end = checkOut ?? checkIn;
+  const span = start && end ? daysBetween(start, end) + 1 : 0;
+  const validSpan = span >= minDays && span <= maxDays;
+
+  const clear = () => {
+    setCheckIn(null);
+    setCheckOut(null);
+  };
+
+  const summary = start
+    ? checkOut && checkOut !== checkIn
+      ? `${niceDate(start)} – ${niceDate(checkOut)} · ${span} days`
+      : `${niceDate(start)} · ${span} day${span > 1 ? 's' : ''}`
+    : null;
+
+  const allowedLabel = formatDurationRange(minDays * MINUTES_PER_DAY, maxDays * MINUTES_PER_DAY);
+  const canReserve = Boolean(start && end && validSpan && !reserving);
+
+  const handleReserve = async () => {
+    if (!start || !end) return;
+    const baseInfo = dayInfo.get(start);
+    const endInfo = dayInfo.get(end);
+    if (!baseInfo?.raw || !endInfo?.endIso) return;
+    setReserving(true);
+    setReserveError(null);
+    try {
+      // Clone the check-in day's slot and extend its end to the check-out day's
+      // end, producing a single multi-day booking entry.
+      const raw = JSON.parse(JSON.stringify(baseInfo.raw));
+      if (raw?.slot) raw.slot.endDate = endInfo.endIso;
+      await reserve(raw);
+    } catch (e) {
+      setReserveError((e as Error)?.message ?? 'Could not start checkout.');
+      setReserving(false);
+    }
+  };
+
+  return (
+    <div className="rounded-2xl border border-line bg-surface p-5 shadow-sm">
+      <p className="text-sm font-semibold tracking-wide text-ink">Reservation details</p>
+
+      <div ref={popRef} className="relative mt-3">
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className="flex w-full items-center gap-2.5 rounded-xl border border-line bg-cream/40 px-3.5 py-3 text-left text-sm text-ink transition-colors hover:border-accent/50"
+        >
+          <CalendarIcon size={18} className="shrink-0 text-muted" />
+          <span className={summary ? '' : 'text-muted'}>{summary ?? 'Select check-in & check-out'}</span>
+        </button>
+
+        {open && (
+          <div className="animate-scale-in absolute right-0 z-30 mt-2 w-[320px] max-w-[calc(100vw-2rem)] rounded-2xl border border-line bg-surface p-4 shadow-xl">
+            <div className="mb-2 flex items-center justify-between">
+              <button
+                type="button"
+                onClick={() => canPrevMonth && goMonth(-1)}
+                disabled={!canPrevMonth}
+                className="rounded-lg p-1.5 text-ink transition-colors enabled:hover:bg-cream disabled:opacity-30"
+                aria-label="Previous month"
+              >
+                <ChevronLeftIcon size={18} />
+              </button>
+              <span className="text-sm font-medium text-ink">
+                {MONTHS[viewMonth]} {viewYear}
+              </span>
+              <button
+                type="button"
+                onClick={() => goMonth(1)}
+                className="rounded-lg p-1.5 text-ink transition-colors hover:bg-cream"
+                aria-label="Next month"
+              >
+                <ChevronRightIcon size={18} />
+              </button>
+            </div>
+
+            <div className="grid grid-cols-7 gap-1 text-center text-xs text-muted">
+              {WEEKDAYS.map((w) => (
+                <div key={w} className="py-1">{w}</div>
+              ))}
+              {monthCells.map((date, i) => {
+                if (!date) return <div key={`e${i}`} />;
+                const key = ymd(date);
+                const info = dayInfo.get(key);
+                const isPast = date < today;
+                const unavailable = isPast || !info?.bookable || disabledAsEnd(key);
+                const isEdge = key === checkIn || key === checkOut;
+                const within = checkIn && checkOut && key > checkIn && key < checkOut;
+                return (
+                  <button
+                    key={key}
+                    type="button"
+                    disabled={unavailable}
+                    onClick={() => pickDay(key)}
+                    className={`aspect-square rounded-lg text-sm transition-colors ${
+                      isEdge
+                        ? 'bg-ink font-semibold text-white'
+                        : within
+                          ? 'bg-accent-soft text-ink'
+                          : unavailable
+                            ? 'cursor-not-allowed text-muted/40'
+                            : 'text-ink hover:bg-cream'
+                    }`}
+                  >
+                    {date.getDate()}
+                  </button>
+                );
+              })}
+            </div>
+
+            <p className="mt-3 text-center text-xs text-muted">
+              {loading
+                ? 'Loading availability…'
+                : error
+                  ? error
+                  : checkIn && !checkOut
+                    ? 'Now pick your check-out day.'
+                    : `Stays of ${allowedLabel}. Dimmed days are unavailable.`}
+            </p>
+
+            <div className="mt-3 flex items-center justify-between border-t border-line pt-3">
+              <button type="button" onClick={clear} className="text-sm text-muted transition-colors hover:text-ink">
+                Clear
+              </button>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                disabled={!canReserve}
+                className="rounded-lg bg-ink px-4 py-2 text-sm font-medium text-white transition-colors enabled:hover:bg-black disabled:cursor-not-allowed disabled:bg-line disabled:text-muted"
+              >
+                Done
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Price + allowed duration */}
+      <div className="mt-4 flex items-baseline justify-between">
+        <div>
+          {priceLabel && <span className="text-xl font-semibold text-ink">{priceLabel}</span>}
+          {priceUnit && <span className="text-sm text-muted"> /{priceUnit}</span>}
+        </div>
+        {allowedLabel && <span className="text-xs text-muted">{allowedLabel} booking</span>}
+      </div>
+
+      {reserveError && <p className="mt-3 text-sm text-red-600">{reserveError}</p>}
+
+      <button
+        type="button"
+        disabled={!canReserve}
+        onClick={handleReserve}
+        className="mt-4 flex w-full items-center justify-center gap-2 rounded-xl bg-accent px-5 py-3 text-sm font-semibold text-white transition-colors enabled:hover:bg-accent-hover disabled:cursor-not-allowed disabled:bg-line disabled:text-muted"
+      >
+        {reserving ? (
+          <>
+            <span className="h-4 w-4 animate-spin rounded-full border-2 border-white/40 border-t-white" />
+            Starting checkout…
+          </>
+        ) : (
+          'Reserve'
+        )}
+      </button>
+      <p className="mt-2 text-center text-xs text-muted">
+        You won’t be charged until you review and confirm at checkout.
+      </p>
+    </div>
+  );
+}

--- a/astro/rentals/src/components/FilterModal.tsx
+++ b/astro/rentals/src/components/FilterModal.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useState } from 'react';
+import { CheckIcon, CloseIcon } from './icons';
+
+export type RentalType = 'HOUR' | 'DAY';
+export type PaymentOption = 'online' | 'inPerson';
+
+export interface RentalFilters {
+  showUnavailable: boolean;
+  features: string[]; // attribute definition ids
+  rentalTypes: RentalType[];
+  payment: PaymentOption[];
+}
+
+export const EMPTY_FILTERS: RentalFilters = {
+  showUnavailable: false,
+  features: [],
+  rentalTypes: [],
+  payment: [],
+};
+
+interface Props {
+  open: boolean;
+  initial: RentalFilters;
+  featureOptions: { id: string; name: string }[];
+  onApply: (filters: RentalFilters) => void;
+  onClose: () => void;
+}
+
+export function FilterModal({ open, initial, featureOptions, onApply, onClose }: Props) {
+  const [showUnavailable, setShowUnavailable] = useState(initial.showUnavailable);
+  const [feats, setFeats] = useState<Set<string>>(new Set(initial.features));
+  const [types, setTypes] = useState<Set<RentalType>>(new Set(initial.rentalTypes));
+  const [pay, setPay] = useState<Set<PaymentOption>>(new Set(initial.payment));
+
+  useEffect(() => {
+    if (open) {
+      setShowUnavailable(initial.showUnavailable);
+      setFeats(new Set(initial.features));
+      setTypes(new Set(initial.rentalTypes));
+      setPay(new Set(initial.payment));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  if (!open) return null;
+
+  const toggle = <T,>(set: Set<T>, value: T): Set<T> => {
+    const next = new Set(set);
+    if (next.has(value)) next.delete(value);
+    else next.add(value);
+    return next;
+  };
+
+  const Check = ({ checked, onChange, label }: { checked: boolean; onChange: () => void; label: string }) => (
+    <button
+      type="button"
+      onClick={onChange}
+      className="flex w-full items-center gap-3 border-b border-line py-3.5 text-left last:border-0"
+    >
+      <span
+        className={`flex h-5 w-5 items-center justify-center rounded border transition-colors ${
+          checked ? 'border-ink bg-ink text-white' : 'border-muted/50'
+        }`}
+      >
+        {checked && <CheckIcon size={13} strokeWidth={2.5} />}
+      </span>
+      <span className="text-ink">{label}</span>
+    </button>
+  );
+
+  return (
+    <div
+      className="animate-fade-in fixed inset-0 z-50 flex items-end justify-center bg-black/40 sm:items-center sm:p-4"
+      onMouseDown={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div className="animate-modal flex max-h-[90vh] w-full max-w-lg flex-col overflow-hidden rounded-t-2xl bg-surface shadow-xl sm:rounded-2xl">
+        <div className="flex items-center justify-between border-b border-line px-6 py-4">
+          <h2 className="text-lg font-semibold tracking-tight text-ink">Filters</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded-lg p-1 text-muted transition-colors hover:bg-cream hover:text-ink"
+          >
+            <CloseIcon size={20} />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-6">
+          <section className="border-b border-line py-5">
+            <p className="mb-3 text-sm font-semibold text-ink">Results preferences</p>
+            <button type="button" onClick={() => setShowUnavailable((v) => !v)} className="flex items-center gap-3">
+              <span className={`relative h-6 w-11 rounded-full transition-colors ${showUnavailable ? 'bg-accent' : 'bg-line'}`}>
+                <span className={`absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-all ${showUnavailable ? 'left-[22px]' : 'left-0.5'}`} />
+              </span>
+              <span className="text-ink">Show unavailable spaces</span>
+            </button>
+          </section>
+
+          {featureOptions.length > 0 && (
+            <section className="border-b border-line py-5">
+              <p className="mb-3 text-sm font-semibold text-ink">Features</p>
+              <div className="flex flex-wrap gap-2">
+                {featureOptions.map((f) => {
+                  const on = feats.has(f.id);
+                  return (
+                    <button
+                      key={f.id}
+                      type="button"
+                      onClick={() => setFeats((s) => toggle(s, f.id))}
+                      className={`rounded-full border px-4 py-2 text-sm transition-colors ${
+                        on ? 'border-ink bg-ink text-white' : 'border-line text-ink hover:border-accent'
+                      }`}
+                    >
+                      {f.name}
+                    </button>
+                  );
+                })}
+              </div>
+            </section>
+          )}
+
+          <section className="border-b border-line py-5">
+            <p className="mb-1 text-sm font-semibold text-ink">Booking type</p>
+            <Check checked={types.has('HOUR')} onChange={() => setTypes((s) => toggle(s, 'HOUR'))} label="Hourly" />
+            <Check checked={types.has('DAY')} onChange={() => setTypes((s) => toggle(s, 'DAY'))} label="Daily" />
+          </section>
+
+          <section className="py-5">
+            <p className="mb-1 text-sm font-semibold text-ink">Payment options</p>
+            <Check checked={pay.has('inPerson')} onChange={() => setPay((s) => toggle(s, 'inPerson'))} label="In person" />
+            <Check checked={pay.has('online')} onChange={() => setPay((s) => toggle(s, 'online'))} label="Online" />
+          </section>
+        </div>
+
+        <div className="flex items-center justify-between border-t border-line px-6 py-4">
+          <button
+            type="button"
+            onClick={() => {
+              setShowUnavailable(false);
+              setFeats(new Set());
+              setTypes(new Set());
+              setPay(new Set());
+            }}
+            className="text-sm text-muted hover:text-ink"
+          >
+            Clear all
+          </button>
+          <button
+            type="button"
+            onClick={() =>
+              onApply({
+                showUnavailable,
+                features: [...feats],
+                rentalTypes: [...types],
+                payment: [...pay],
+              })
+            }
+            className="rounded-xl bg-ink px-6 py-2.5 text-sm font-semibold text-white hover:bg-black"
+          >
+            Apply
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/astro/rentals/src/components/Footer.tsx
+++ b/astro/rentals/src/components/Footer.tsx
@@ -1,0 +1,10 @@
+export function Footer() {
+  return (
+    <footer className="mt-20 border-t border-line bg-cream-deep">
+      <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-2 px-4 py-8 text-sm text-muted sm:flex-row sm:px-6">
+        <p>© {new Date().getFullYear()} Wix Rentals</p>
+        <p>Secure checkout powered by Wix</p>
+      </div>
+    </footer>
+  );
+}

--- a/astro/rentals/src/components/Navbar.tsx
+++ b/astro/rentals/src/components/Navbar.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { ChevronDownIcon, KeyIcon } from './icons';
+import { Avatar } from './ui';
+import { useAuth } from '../lib/auth';
+
+export function Navbar() {
+  const { loggedIn, member, login, logout } = useAuth();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [loggingIn, setLoggingIn] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onDoc = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setMenuOpen(false);
+    };
+    document.addEventListener('mousedown', onDoc);
+    return () => document.removeEventListener('mousedown', onDoc);
+  }, [menuOpen]);
+
+  return (
+    <header className="sticky top-0 z-20 border-b border-line bg-cream/85 backdrop-blur">
+      <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-4 sm:px-6">
+        <Link
+          to="/"
+          className="flex items-center gap-2.5 text-lg font-semibold tracking-tight text-ink"
+        >
+          <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-ink text-white">
+            <KeyIcon size={17} />
+          </span>
+          <span>Wix Rentals</span>
+        </Link>
+
+        {loggedIn ? (
+          <div ref={ref} className="relative">
+            <button
+              type="button"
+              onClick={() => setMenuOpen((v) => !v)}
+              className="flex items-center gap-2 rounded-full border border-line bg-surface py-1 pl-1 pr-2.5 text-sm font-medium text-ink transition-colors hover:border-accent"
+            >
+              <Avatar name={member?.name} photo={member?.photo} className="h-7 w-7" textClass="text-xs" />
+              <span className="hidden max-w-[10rem] truncate sm:inline">
+                {member?.name ?? 'Account'}
+              </span>
+              <ChevronDownIcon
+                size={15}
+                className={`text-muted transition-transform duration-200 ${menuOpen ? 'rotate-180' : ''}`}
+              />
+            </button>
+            {menuOpen && (
+              <div className="animate-scale-in absolute right-0 z-40 mt-2 w-44 overflow-hidden rounded-xl border border-line bg-surface py-1 shadow-xl">
+                <Link
+                  to="/account"
+                  onClick={() => setMenuOpen(false)}
+                  className="block px-4 py-2.5 text-sm text-ink transition-colors hover:bg-cream"
+                >
+                  My account
+                </Link>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setMenuOpen(false);
+                    logout();
+                  }}
+                  className="block w-full px-4 py-2.5 text-left text-sm text-ink transition-colors hover:bg-cream"
+                >
+                  Log out
+                </button>
+              </div>
+            )}
+          </div>
+        ) : (
+          <button
+            type="button"
+            disabled={loggingIn}
+            onClick={() => {
+              setLoggingIn(true);
+              login('/account').catch(() => setLoggingIn(false));
+            }}
+            className="flex items-center gap-2 rounded-xl border border-line bg-surface px-4 py-2 text-sm font-medium text-ink transition-colors hover:border-accent disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {loggingIn && (
+              <span className="h-4 w-4 animate-spin rounded-full border-2 border-line border-t-accent" />
+            )}
+            {loggingIn ? 'Signing in…' : 'Log in'}
+          </button>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/astro/rentals/src/components/RentalCard.tsx
+++ b/astro/rentals/src/components/RentalCard.tsx
@@ -1,0 +1,73 @@
+import { Link } from 'react-router-dom';
+import type { RentalSummary } from '../lib/types';
+import { formatDurationRange, formatMoney } from '../lib/format';
+import { ArrowRightIcon, BuildingIcon } from './icons';
+
+export function RentalCard({
+  rental,
+  queryDate,
+}: {
+  rental: RentalSummary;
+  queryDate?: string;
+}) {
+  const price = formatMoney(rental.price);
+  const to = queryDate
+    ? `/rental/${encodeURIComponent(rental.slug)}?date=${queryDate}`
+    : `/rental/${encodeURIComponent(rental.slug)}`;
+  const badge =
+    rental.rentalUnit === 'DAY' ? 'Daily' : rental.rentalUnit === 'HOUR' ? 'Hourly' : null;
+  const minMax =
+    formatDurationRange(rental.minMinutes, rental.maxMinutes) ?? rental.durationLabel;
+
+  return (
+    <div className="group flex flex-col">
+      <Link
+        to={to}
+        className="hover-lift relative block aspect-[4/3] overflow-hidden rounded-2xl border border-line bg-cream-deep"
+      >
+        {rental.image ? (
+          <img
+            src={rental.image.url}
+            alt={rental.image.altText ?? rental.name}
+            loading="lazy"
+            className="h-full w-full object-cover transition-transform duration-500 ease-out group-hover:scale-[1.04]"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-muted">
+            <BuildingIcon size={44} />
+          </div>
+        )}
+        {badge && (
+          <span className="absolute right-3 top-3 rounded-full bg-surface/95 px-3 py-1 text-xs font-medium text-ink shadow-sm ring-1 ring-line">
+            {badge}
+          </span>
+        )}
+      </Link>
+
+      <div className="mt-3">
+        <Link to={to}>
+          <h3 className="text-lg font-semibold tracking-tight text-ink transition-colors group-hover:text-accent">
+            {rental.name}
+          </h3>
+        </Link>
+        {price && (
+          <p className="mt-1 text-ink">
+            <span className="font-semibold">{price}</span>
+            {rental.priceUnit && <span className="text-muted"> / {rental.priceUnit}</span>}
+          </p>
+        )}
+        {minMax && <p className="mt-0.5 text-sm text-muted">{minMax}</p>}
+        <Link
+          to={to}
+          className="group/link mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-accent transition-colors hover:text-accent-hover"
+        >
+          View & reserve
+          <ArrowRightIcon
+            size={16}
+            className="transition-transform duration-200 group-hover/link:translate-x-0.5"
+          />
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/astro/rentals/src/components/RescheduleModal.tsx
+++ b/astro/rentals/src/components/RescheduleModal.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  buildRescheduledSlot,
+  getAvailability,
+  rescheduleMyBooking,
+  type MyBooking,
+} from '../lib/rentals';
+import type { AvailabilitySlot } from '../lib/types';
+import { CloseIcon } from './icons';
+import { formatMinutes, toLocalDateTime } from '../lib/format';
+
+const pad = (n: number) => String(n).padStart(2, '0');
+const todayYmd = () => {
+  const d = new Date();
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+};
+
+interface Props {
+  booking: MyBooking;
+  onClose: () => void;
+  onDone: () => void;
+}
+
+export function RescheduleModal({ booking, onClose, onDone }: Props) {
+  const [date, setDate] = useState(todayYmd());
+  const [slots, setSlots] = useState<AvailabilitySlot[]>([]);
+  const [selected, setSelected] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setSelected('');
+    getAvailability(booking.serviceId, `${date}T00:00:00`, `${date}T23:59:59`)
+      .then((r) => !cancelled && setSlots(r.slots.filter((s) => s.bookable)))
+      .catch((e) => !cancelled && setError(e?.message ?? 'Could not load availability.'))
+      .finally(() => !cancelled && setLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [booking.serviceId, date]);
+
+  // Unique bookable starts on the chosen date (drop past times if it's today).
+  const options = useMemo(() => {
+    const now = toLocalDateTime(new Date());
+    const isToday = date === todayYmd();
+    const seen = new Set<string>();
+    return slots
+      .filter((s) => (!isToday || s.localStartDate > now) && !seen.has(s.localStartDate) && seen.add(s.localStartDate))
+      .sort((a, b) => (a.localStartDate < b.localStartDate ? -1 : 1))
+      .map((s) => ({
+        key: s.key,
+        label: booking.unit === 'DAY' ? 'All day' : s.startLabel,
+      }));
+  }, [slots, date, booking.unit]);
+
+  const confirm = async () => {
+    const slot = slots.find((s) => s.key === selected);
+    if (!slot) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const newSlot = buildRescheduledSlot(slot.raw, booking.durationMinutes);
+      await rescheduleMyBooking(booking.id, booking.revision, newSlot);
+      onDone();
+    } catch (e) {
+      setError((e as Error)?.message ?? 'Could not reschedule this booking.');
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      className="animate-fade-in fixed inset-0 z-50 flex items-end justify-center bg-black/40 sm:items-center sm:p-4"
+      onMouseDown={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div className="animate-modal w-full max-w-md rounded-t-2xl bg-surface shadow-xl sm:rounded-2xl">
+        <div className="flex items-center justify-between border-b border-line px-6 py-4">
+          <h2 className="text-lg font-semibold tracking-tight text-ink">Reschedule booking</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded-lg p-1 text-muted transition-colors hover:bg-cream hover:text-ink"
+          >
+            <CloseIcon size={20} />
+          </button>
+        </div>
+
+        <div className="space-y-4 px-6 py-5">
+          <p className="text-sm text-muted">
+            <span className="text-ink-soft">{booking.title}</span> · currently {booking.when}
+          </p>
+
+          <label className="block">
+            <span className="mb-1 block text-sm font-medium text-ink">New date</span>
+            <input
+              type="date"
+              min={todayYmd()}
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+              className="w-full rounded-lg border border-line bg-surface px-3 py-2 text-sm text-ink outline-none focus:border-accent"
+            />
+          </label>
+
+          <div>
+            <span className="mb-1 block text-sm font-medium text-ink">New time</span>
+            {loading ? (
+              <p className="text-sm text-muted">Loading availability…</p>
+            ) : error ? (
+              <p className="text-sm text-red-600">{error}</p>
+            ) : options.length === 0 ? (
+              <p className="text-sm text-muted">No availability on this date — try another.</p>
+            ) : (
+              <select
+                value={selected}
+                onChange={(e) => setSelected(e.target.value)}
+                className="w-full rounded-lg border border-line bg-surface px-3 py-2 text-sm text-ink outline-none focus:border-accent"
+              >
+                <option value="">Select a time</option>
+                {options.map((o) => (
+                  <option key={o.key} value={o.key}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+          <p className="text-xs text-muted">
+            Your booking keeps its original length ({formatMinutes(booking.durationMinutes)}).
+          </p>
+        </div>
+
+        <div className="flex items-center justify-end gap-2 border-t border-line px-6 py-4">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-xl px-4 py-2.5 text-sm font-medium text-muted transition-colors hover:text-ink"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={confirm}
+            disabled={!selected || saving}
+            className="inline-flex items-center gap-2 rounded-xl bg-accent px-5 py-2.5 text-sm font-semibold text-white transition-colors enabled:hover:bg-accent-hover disabled:cursor-not-allowed disabled:bg-line disabled:text-muted"
+          >
+            {saving && <span className="h-4 w-4 animate-spin rounded-full border-2 border-white/40 border-t-white" />}
+            Confirm reschedule
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/astro/rentals/src/components/ReservationPanel.tsx
+++ b/astro/rentals/src/components/ReservationPanel.tsx
@@ -1,0 +1,380 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { getAvailability, reserve } from '../lib/rentals';
+import type { AvailabilitySlot } from '../lib/types';
+import { formatDurationRange, formatTimeLabel } from '../lib/format';
+import { CalendarIcon, ChevronLeftIcon, ChevronRightIcon } from './icons';
+
+const WEEKDAYS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+const MONTHS = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+const pad = (n: number) => String(n).padStart(2, '0');
+const ymd = (d: Date) => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+const localDT = (d: Date) =>
+  `${ymd(d)}T${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+const parseYmd = (s: string) => {
+  const [y, m, d] = s.split('-').map(Number);
+  return new Date(y, m - 1, d);
+};
+
+interface LocationInfo {
+  name?: string;
+  address?: string;
+}
+
+interface Props {
+  serviceId: string;
+  minMinutes: number;
+  maxMinutes: number;
+  priceLabel?: string;
+  priceUnit?: string;
+  initialDate?: string;
+  onLocation?: (loc: LocationInfo | null) => void;
+}
+
+export function ReservationPanel({
+  serviceId,
+  minMinutes,
+  maxMinutes,
+  priceLabel,
+  priceUnit,
+  initialDate,
+  onLocation,
+}: Props) {
+  const today = useMemo(() => {
+    const d = new Date();
+    d.setHours(0, 0, 0, 0);
+    return d;
+  }, []);
+  const todayKey = ymd(today);
+  const startBase = initialDate ? parseYmd(initialDate) : today;
+
+  const [open, setOpen] = useState(false);
+  const [selectedDate, setSelectedDate] = useState<string | null>(initialDate ?? null);
+  const [viewYear, setViewYear] = useState(startBase.getFullYear());
+  const [viewMonth, setViewMonth] = useState(startBase.getMonth());
+  const [slots, setSlots] = useState<AvailabilitySlot[]>([]);
+  const [timeZone, setTimeZone] = useState<string | undefined>();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [startTime, setStartTime] = useState('');
+  const [endTime, setEndTime] = useState('');
+  const [reserving, setReserving] = useState(false);
+  const [reserveError, setReserveError] = useState<string | null>(null);
+  const popRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!selectedDate) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setStartTime('');
+    setEndTime('');
+    getAvailability(serviceId, `${selectedDate}T00:00:00`, `${selectedDate}T23:59:59`)
+      .then((res) => {
+        if (cancelled) return;
+        setSlots(res.slots);
+        setTimeZone(res.timeZone);
+        onLocation?.(res.slots[0]?.location ?? null);
+      })
+      .catch((e) => !cancelled && setError(e?.message ?? 'Could not load availability.'))
+      .finally(() => !cancelled && setLoading(false));
+    return () => {
+      cancelled = true;
+    };
+    // onLocation intentionally omitted to avoid refetch loops
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [serviceId, selectedDate]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (popRef.current && !popRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onDoc);
+    return () => document.removeEventListener('mousedown', onDoc);
+  }, [open]);
+
+  const byStart = useMemo(() => {
+    const m = new Map<string, AvailabilitySlot>();
+    for (const s of slots) if (s.bookable) m.set(s.localStartDate, s);
+    return m;
+  }, [slots]);
+
+  const startOptions = useMemo(() => {
+    const nowIso = localDT(new Date());
+    const isToday = selectedDate === todayKey;
+    return slots
+      .filter((s) => s.bookable)
+      .filter((s) => !isToday || s.localStartDate > nowIso)
+      .map((s) => s.localStartDate)
+      .filter((v, i, a) => a.indexOf(v) === i)
+      .sort();
+  }, [slots, selectedDate, todayKey]);
+
+  const endOptions = useMemo(() => {
+    type Opt = { value: string; endIso: string; label: string; hours: number };
+    if (!startTime) return [] as Opt[];
+    const base = byStart.get(startTime);
+    if (!base) return [] as Opt[];
+    // The atomic bookable unit for this service — e.g. 60 min for an hourly room,
+    // or a fixed 240 min for a 4-hour-only room. A booking spans whole multiples of
+    // it, so we must step by this (not a hardcoded hour) or we'd overshoot the end.
+    const slotMinutes = Math.max(
+      1,
+      Math.round(
+        (new Date(base.localEndDate).getTime() - new Date(base.localStartDate).getTime()) / 60000,
+      ),
+    );
+    const minUnits = Math.max(1, Math.round(minMinutes / slotMinutes));
+    const maxUnits = Math.max(minUnits, Math.round(maxMinutes / slotMinutes));
+    const start = new Date(startTime);
+    const opts: Opt[] = [];
+    for (let k = 1; k <= maxUnits; k++) {
+      // Each consecutive unit [start+(k-1) units] must be bookable for the span to be free.
+      const unitStart = new Date(start);
+      unitStart.setMinutes(unitStart.getMinutes() + (k - 1) * slotMinutes);
+      const block = byStart.get(localDT(unitStart));
+      if (!block) break; // stop at first gap
+      if (k >= minUnits) {
+        opts.push({
+          value: block.localEndDate, // wall-clock end of the span (start + k units)
+          endIso: (block.raw as { slot?: { endDate?: string } })?.slot?.endDate ?? '',
+          label: formatTimeLabel(block.localEndDate),
+          hours: (k * slotMinutes) / 60,
+        });
+      }
+    }
+    return opts;
+  }, [startTime, byStart, minMinutes, maxMinutes]);
+
+  const monthCells = useMemo(() => {
+    const first = new Date(viewYear, viewMonth, 1);
+    const daysInMonth = new Date(viewYear, viewMonth + 1, 0).getDate();
+    const cells: (Date | null)[] = [];
+    for (let i = 0; i < first.getDay(); i++) cells.push(null);
+    for (let d = 1; d <= daysInMonth; d++) cells.push(new Date(viewYear, viewMonth, d));
+    return cells;
+  }, [viewYear, viewMonth]);
+
+  const canPrevMonth =
+    viewYear > today.getFullYear() ||
+    (viewYear === today.getFullYear() && viewMonth > today.getMonth());
+
+  const goMonth = (delta: number) => {
+    const m = viewMonth + delta;
+    const d = new Date(viewYear, m, 1);
+    setViewYear(d.getFullYear());
+    setViewMonth(d.getMonth());
+  };
+
+  const durationLabel = () => formatDurationRange(minMinutes, maxMinutes) ?? '';
+
+  const canReserve = Boolean(selectedDate && startTime && endTime && !reserving);
+
+  const handleReserve = async () => {
+    const base = byStart.get(startTime);
+    const opt = endOptions.find((o) => o.value === endTime);
+    if (!base || !opt) return;
+    setReserving(true);
+    setReserveError(null);
+    try {
+      // Clone the SlotAvailability entry and extend its end for multi-hour rentals.
+      const raw = JSON.parse(JSON.stringify(base.raw));
+      if (raw?.slot && opt.endIso) raw.slot.endDate = opt.endIso;
+      await reserve(raw);
+    } catch (e) {
+      setReserveError((e as Error)?.message ?? 'Could not start checkout.');
+      setReserving(false);
+    }
+  };
+
+  const summary =
+    selectedDate && startTime && endTime
+      ? `${parseYmd(selectedDate).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })} · ${formatTimeLabel(startTime)} – ${formatTimeLabel(endTime)}`
+      : null;
+
+  return (
+    <div className="rounded-2xl border border-line bg-surface p-5 shadow-sm">
+      <p className="text-sm font-semibold tracking-wide text-ink">Reservation details</p>
+
+      <div ref={popRef} className="relative mt-3">
+        {/* Date/time field */}
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className="flex w-full items-center gap-2.5 rounded-xl border border-line bg-cream/40 px-3.5 py-3 text-left text-sm text-ink transition-colors hover:border-accent/50"
+        >
+          <CalendarIcon size={18} className="shrink-0 text-muted" />
+          <span className={summary ? '' : 'text-muted'}>
+            {summary ?? (selectedDate ?? 'Select a date & time')}
+          </span>
+        </button>
+
+        {/* Popover */}
+        {open && (
+          <div className="animate-scale-in absolute right-0 z-30 mt-2 w-[520px] max-w-[calc(100vw-2rem)] rounded-2xl border border-line bg-surface p-4 shadow-xl">
+            <div className="flex flex-col gap-5 sm:flex-row">
+              {/* Calendar */}
+              <div className="sm:w-1/2">
+                <div className="mb-2 flex items-center justify-between">
+                  <button
+                    type="button"
+                    onClick={() => canPrevMonth && goMonth(-1)}
+                    disabled={!canPrevMonth}
+                    className="rounded-lg p-1.5 text-ink transition-colors enabled:hover:bg-cream disabled:opacity-30"
+                    aria-label="Previous month"
+                  >
+                    <ChevronLeftIcon size={18} />
+                  </button>
+                  <span className="text-sm font-medium text-ink">
+                    {MONTHS[viewMonth]} {viewYear}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => goMonth(1)}
+                    className="rounded-lg p-1.5 text-ink transition-colors hover:bg-cream"
+                    aria-label="Next month"
+                  >
+                    <ChevronRightIcon size={18} />
+                  </button>
+                </div>
+                <div className="grid grid-cols-7 gap-1 text-center text-xs text-muted">
+                  {WEEKDAYS.map((w) => (
+                    <div key={w} className="py-1">{w}</div>
+                  ))}
+                  {monthCells.map((date, i) => {
+                    if (!date) return <div key={`e${i}`} />;
+                    const key = ymd(date);
+                    const isPast = date < today;
+                    const isToday = key === todayKey;
+                    const isSelected = key === selectedDate;
+                    return (
+                      <button
+                        key={key}
+                        type="button"
+                        disabled={isPast}
+                        onClick={() => setSelectedDate(key)}
+                        className={`aspect-square rounded-lg text-sm transition-colors ${
+                          isSelected
+                            ? 'bg-ink font-semibold text-white ring-2 ring-accent ring-offset-1'
+                            : isPast
+                              ? 'cursor-not-allowed text-muted/40'
+                              : 'text-ink hover:bg-cream'
+                        } ${isToday && !isSelected ? 'ring-1 ring-inset ring-line' : ''}`}
+                      >
+                        {date.getDate()}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {/* Times */}
+              <div className="sm:w-1/2">
+                {!selectedDate ? (
+                  <p className="pt-2 text-sm text-muted">Pick a date to see available times.</p>
+                ) : loading ? (
+                  <p className="pt-2 text-sm text-muted">Loading times…</p>
+                ) : error ? (
+                  <p className="pt-2 text-sm text-red-600">{error}</p>
+                ) : startOptions.length === 0 ? (
+                  <p className="pt-2 text-sm text-muted">No availability on this date.</p>
+                ) : (
+                  <div className="space-y-3">
+                    <label className="block">
+                      <span className="mb-1 block text-sm text-ink">Start time</span>
+                      <select
+                        value={startTime}
+                        onChange={(e) => {
+                          setStartTime(e.target.value);
+                          setEndTime('');
+                        }}
+                        className="w-full rounded-lg border border-line bg-surface px-3 py-2 text-sm text-ink outline-none focus:border-accent"
+                      >
+                        <option value="">Select</option>
+                        {startOptions.map((s) => (
+                          <option key={s} value={s}>{formatTimeLabel(s)}</option>
+                        ))}
+                      </select>
+                    </label>
+                    <label className="block">
+                      <span className="mb-1 block text-sm text-ink">End time</span>
+                      <select
+                        value={endTime}
+                        onChange={(e) => setEndTime(e.target.value)}
+                        disabled={!startTime}
+                        className="w-full rounded-lg border border-line bg-surface px-3 py-2 text-sm text-ink outline-none focus:border-accent disabled:opacity-50"
+                      >
+                        <option value="">Select</option>
+                        {endOptions.map((o) => (
+                          <option key={o.value} value={o.value}>
+                            {o.label} · {o.hours}h
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="mt-4 flex items-center justify-between border-t border-line pt-3">
+              <button
+                type="button"
+                onClick={() => {
+                  setSelectedDate(null);
+                  setStartTime('');
+                  setEndTime('');
+                }}
+                className="text-sm text-muted hover:text-ink"
+              >
+                Clear
+              </button>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                disabled={!(selectedDate && startTime && endTime)}
+                className="rounded-lg bg-ink px-4 py-2 text-sm font-medium text-white transition-colors enabled:hover:bg-black disabled:cursor-not-allowed disabled:bg-line disabled:text-muted"
+              >
+                Select
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Price + duration */}
+      <div className="mt-4 flex items-baseline justify-between">
+        <div>
+          {priceLabel && <span className="text-xl font-semibold text-ink">{priceLabel}</span>}
+          {priceUnit && <span className="text-sm text-muted"> /{priceUnit}</span>}
+        </div>
+        <span className="text-xs text-muted">{durationLabel()} booking</span>
+      </div>
+
+      {reserveError && <p className="mt-3 text-sm text-red-600">{reserveError}</p>}
+
+      <button
+        type="button"
+        disabled={!canReserve}
+        onClick={handleReserve}
+        className="mt-4 flex w-full items-center justify-center gap-2 rounded-xl bg-accent px-5 py-3 text-sm font-semibold text-white transition-colors enabled:hover:bg-accent-hover disabled:cursor-not-allowed disabled:bg-line disabled:text-muted"
+      >
+        {reserving ? (
+          <>
+            <span className="h-4 w-4 animate-spin rounded-full border-2 border-white/40 border-t-white" />
+            Starting checkout…
+          </>
+        ) : (
+          'Reserve'
+        )}
+      </button>
+      <p className="mt-2 text-center text-xs text-muted">
+        You won’t be charged until you review and confirm at checkout.
+      </p>
+    </div>
+  );
+}

--- a/astro/rentals/src/components/icons.tsx
+++ b/astro/rentals/src/components/icons.tsx
@@ -1,0 +1,152 @@
+import type { SVGProps } from 'react';
+
+/** Lightweight stroke icon set (lucide-style). All icons inherit `currentColor`
+ *  and a consistent 1.75 stroke, so they sit neutrally next to text. */
+
+type IconProps = SVGProps<SVGSVGElement> & { size?: number };
+
+function Icon({ size = 20, children, ...props }: IconProps & { children: React.ReactNode }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.75}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...props}
+    >
+      {children}
+    </svg>
+  );
+}
+
+export const CalendarIcon = (p: IconProps) => (
+  <Icon {...p}>
+    <rect x="3" y="4.5" width="18" height="16" rx="2.5" />
+    <path d="M3 9h18M8 2.5v4M16 2.5v4" />
+  </Icon>
+);
+
+export const SearchIcon = (p: IconProps) => (
+  <Icon {...p}>
+    <circle cx="11" cy="11" r="7" />
+    <path d="m20 20-3.2-3.2" />
+  </Icon>
+);
+
+export const FilterIcon = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="M4 6h16M7 12h10M10 18h4" />
+  </Icon>
+);
+
+export const ChevronLeftIcon = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="m15 6-6 6 6 6" />
+  </Icon>
+);
+
+export const ChevronRightIcon = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="m9 6 6 6-6 6" />
+  </Icon>
+);
+
+export const ChevronDownIcon = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="m6 9 6 6 6-6" />
+  </Icon>
+);
+
+export const ArrowRightIcon = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="M5 12h14M13 6l6 6-6 6" />
+  </Icon>
+);
+
+export const CheckIcon = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="m5 12.5 4.5 4.5L19 7" />
+  </Icon>
+);
+
+export const CheckCircleIcon = (p: IconProps) => (
+  <Icon {...p}>
+    <circle cx="12" cy="12" r="9" />
+    <path d="m8.5 12 2.5 2.5 4.5-5" />
+  </Icon>
+);
+
+export const CloseIcon = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="M6 6l12 12M18 6 6 18" />
+  </Icon>
+);
+
+export const MapPinIcon = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="M20 10c0 5.2-8 12-8 12s-8-6.8-8-12a8 8 0 0 1 16 0Z" />
+    <circle cx="12" cy="10" r="2.75" />
+  </Icon>
+);
+
+export const ClockIcon = (p: IconProps) => (
+  <Icon {...p}>
+    <circle cx="12" cy="12" r="9" />
+    <path d="M12 7.5V12l3 2" />
+  </Icon>
+);
+
+export const ShieldIcon = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="M12 3 5 6v5.5c0 4.3 3 7.5 7 9.5 4-2 7-5.2 7-9.5V6l-7-3Z" />
+    <path d="m9.2 12 2 2 3.6-4" />
+  </Icon>
+);
+
+export const CardIcon = (p: IconProps) => (
+  <Icon {...p}>
+    <rect x="3" y="5" width="18" height="14" rx="2.5" />
+    <path d="M3 9.5h18M7 15h4" />
+  </Icon>
+);
+
+export const UserIcon = (p: IconProps) => (
+  <Icon {...p}>
+    <circle cx="12" cy="8" r="4" />
+    <path d="M5 20a7 7 0 0 1 14 0" />
+  </Icon>
+);
+
+export const UsersIcon = (p: IconProps) => (
+  <Icon {...p}>
+    <circle cx="9" cy="8" r="3.25" />
+    <path d="M3.5 19a5.5 5.5 0 0 1 11 0" />
+    <path d="M16 5.2a3.25 3.25 0 0 1 0 6.1M17.5 19a5.5 5.5 0 0 0-2.4-4.5" />
+  </Icon>
+);
+
+export const BuildingIcon = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="M4 21h16M6 21V5a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v16" />
+    <path d="M9.5 7h1M13.5 7h1M9.5 11h1M13.5 11h1M9.5 15h1M13.5 15h1M10 21v-3h4v3" />
+  </Icon>
+);
+
+export const RefreshIcon = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="M4 12a8 8 0 0 1 13.7-5.6L20 8M20 4v4h-4" />
+    <path d="M20 12a8 8 0 0 1-13.7 5.6L4 16M4 20v-4h4" />
+  </Icon>
+);
+
+export const KeyIcon = (p: IconProps) => (
+  <Icon {...p}>
+    <circle cx="8" cy="8" r="4.5" />
+    <path d="m11.2 11.2 7.3 7.3M16 16l2-2M18.5 13.5l1.5 1.5" />
+  </Icon>
+);

--- a/astro/rentals/src/components/ui.tsx
+++ b/astro/rentals/src/components/ui.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState, type ReactNode } from 'react';
+
+/** Member avatar with graceful fallbacks. Social-login photos (e.g. Google's
+ *  `lh3.googleusercontent.com` URLs) reject requests that carry a referrer, so
+ *  we send none; if the image still fails to load we fall back to the initial
+ *  instead of a broken-image icon. */
+export function Avatar({
+  name,
+  photo,
+  className = 'h-7 w-7',
+  textClass = 'text-xs',
+}: {
+  name?: string;
+  photo?: string;
+  className?: string;
+  textClass?: string;
+}) {
+  const [failed, setFailed] = useState(false);
+  useEffect(() => setFailed(false), [photo]);
+
+  if (photo && !failed) {
+    return (
+      <img
+        src={photo}
+        alt=""
+        referrerPolicy="no-referrer"
+        onError={() => setFailed(true)}
+        className={`shrink-0 rounded-full object-cover ${className}`}
+      />
+    );
+  }
+
+  const initial = (name ?? 'M').trim().charAt(0).toUpperCase();
+  return (
+    <span
+      className={`flex shrink-0 items-center justify-center rounded-full bg-ink font-semibold text-white ${textClass} ${className}`}
+    >
+      {initial}
+    </span>
+  );
+}
+
+export function Spinner({ label }: { label?: string }) {
+  return (
+    <div className="flex items-center justify-center gap-3 py-16 text-muted">
+      <span className="h-5 w-5 animate-spin rounded-full border-2 border-line border-t-accent" />
+      {label && <span className="text-sm">{label}</span>}
+    </div>
+  );
+}
+
+export function ErrorNote({ title, detail }: { title: string; detail?: string }) {
+  return (
+    <div className="animate-fade-in rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+      <p className="font-semibold">{title}</p>
+      {detail && <p className="mt-1 text-red-700/80">{detail}</p>}
+    </div>
+  );
+}
+
+export function EmptyState({ title, children }: { title: string; children?: ReactNode }) {
+  return (
+    <div className="animate-fade-in rounded-2xl border border-dashed border-line bg-surface px-6 py-16 text-center">
+      <p className="text-base font-medium text-ink">{title}</p>
+      {children && <div className="mx-auto mt-2 max-w-md text-sm text-muted">{children}</div>}
+    </div>
+  );
+}
+
+export function ConfigBanner() {
+  return (
+    <div className="border-b border-amber-200 bg-amber-50 px-4 py-2.5 text-center text-sm text-amber-900">
+      <span className="font-semibold">Setup needed:</span> add your Headless{' '}
+      <code className="rounded bg-amber-100 px-1 py-0.5">PUBLIC_WIX_CLIENT_ID</code> to a{' '}
+      <code className="rounded bg-amber-100 px-1 py-0.5">.env</code> file, then restart the dev
+      server.
+    </div>
+  );
+}

--- a/astro/rentals/src/env.d.ts
+++ b/astro/rentals/src/env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="astro/client" />
+
+interface ImportMetaEnv {
+  readonly PUBLIC_WIX_CLIENT_ID: string;
+  readonly PUBLIC_WIX_RENTALS_APP_ID?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/astro/rentals/src/layouts/Layout.astro
+++ b/astro/rentals/src/layouts/Layout.astro
@@ -1,0 +1,27 @@
+---
+import '../styles/global.css';
+---
+
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<link
+			rel="icon"
+			href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' rx='8' fill='%23141820'/><g transform='translate(4 4)' fill='none' stroke='white' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'><circle cx='8' cy='8' r='4.5'/><path d='m11.2 11.2 7.3 7.3M16 16l2-2M18.5 13.5l1.5 1.5'/></g></svg>"
+		/>
+		<link rel="preconnect" href="https://fonts.googleapis.com" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+		<link
+			href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+			rel="stylesheet"
+		/>
+		<meta name="generator" content={Astro.generator} />
+		<meta name="description" content="Browse and book spaces online." />
+		<title>Wix Rentals</title>
+	</head>
+	<body>
+		<slot />
+	</body>
+</html>

--- a/astro/rentals/src/lib/auth.tsx
+++ b/astro/rentals/src/lib/auth.tsx
@@ -1,0 +1,78 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react';
+import { getCurrentMember, isLoggedIn, login as doLogin, logout as doLogout } from './wix-client';
+
+export interface Member {
+  id?: string;
+  name?: string;
+  email?: string;
+  photo?: string;
+}
+
+interface AuthValue {
+  member: Member | null;
+  loggedIn: boolean;
+  loading: boolean;
+  login: (returnTo?: string) => Promise<void>;
+  logout: () => void;
+  refresh: () => void;
+}
+
+const AuthContext = createContext<AuthValue | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [member, setMember] = useState<Member | null>(null);
+  const [loading, setLoading] = useState(isLoggedIn());
+
+  const refresh = useCallback(() => {
+    if (!isLoggedIn()) {
+      setMember(null);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    getCurrentMember()
+      .then((m) => setMember(m))
+      .catch(() => setMember(null))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const value: AuthValue = {
+    member,
+    loggedIn: isLoggedIn(),
+    loading,
+    login: (returnTo) =>
+      doLogin(returnTo).catch((e) => {
+        // eslint-disable-next-line no-console
+        console.error('[auth] login failed', e);
+        // Re-throw so callers can clear their pending/loading UI. On success the
+        // browser redirects away, so the promise never visibly resolves.
+        throw e;
+      }),
+    logout: () => {
+      doLogout().catch((e) => {
+        // eslint-disable-next-line no-console
+        console.error('[auth] logout failed', e);
+      });
+    },
+    refresh,
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth(): AuthValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+}

--- a/astro/rentals/src/lib/format.ts
+++ b/astro/rentals/src/lib/format.ts
@@ -1,0 +1,132 @@
+import type { Money, PolicyItem, RentalDetails } from './types';
+
+/** Resolve a Wix media URL (handles `wix:image://` internal URIs) into a
+ *  sized static URL. Verified against static.wixstatic.com (200 image/jpeg). */
+export function resolveWixImage(url?: string, width = 900, height = 675): string | undefined {
+  if (!url) return undefined;
+  if (url.startsWith('http')) return url;
+  if (url.startsWith('wix:image://')) {
+    // wix:image://v1/<mediaId>/<filename>#originWidth=..&originHeight=..
+    const rest = url.replace('wix:image://v1/', '');
+    const mediaId = rest.split('#')[0].split('/')[0];
+    return `https://static.wixstatic.com/media/${mediaId}/v1/fill/w_${width},h_${height},al_c,q_80,enc_auto/image.jpg`;
+  }
+  return url;
+}
+
+/** Format a Money-like value for display. */
+export function formatMoney(price?: Money): string | undefined {
+  if (!price) return undefined;
+  if (price.formatted) return price.formatted;
+  if (price.amount != null) {
+    const num = Number(price.amount);
+    if (!Number.isNaN(num)) {
+      return new Intl.NumberFormat(undefined, {
+        style: 'currency',
+        currency: price.currency || 'USD',
+      }).format(num);
+    }
+    return `${price.amount} ${price.currency ?? ''}`.trim();
+  }
+  return undefined;
+}
+
+/** Turn a duration in minutes into a friendly label ("1 hr 30 min"). */
+export function formatMinutes(minutes?: number): string | undefined {
+  if (!minutes || minutes <= 0) return undefined;
+  if (minutes % (60 * 24) === 0) {
+    const days = minutes / (60 * 24);
+    return `${days} day${days > 1 ? 's' : ''}`;
+  }
+  const hrs = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  const parts: string[] = [];
+  if (hrs) parts.push(`${hrs} hr`);
+  if (mins) parts.push(`${mins} min`);
+  return parts.join(' ');
+}
+
+/** Human-friendly booking length: a single value when the min and max are the
+ *  same (a fixed-length booking, e.g. "4 hr"), or a range otherwise
+ *  (e.g. "1 hr – 8 hr"). Avoids confusing "4 hr – 4 hr" output. */
+export function formatDurationRange(
+  minMinutes?: number,
+  maxMinutes?: number,
+): string | undefined {
+  const min = formatMinutes(minMinutes);
+  if (!min) return undefined;
+  if (!maxMinutes || maxMinutes === minMinutes) return min;
+  const max = formatMinutes(maxMinutes);
+  return max ? `${min} – ${max}` : min;
+}
+
+/** Local date/time helpers — Wix availability uses local `YYYY-MM-DDThh:mm:ss`. */
+export function toLocalDateTime(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+    `T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`
+  );
+}
+
+/** Build a plain-language booking policy from a rental's cancellation, payment
+ *  and capacity settings. Each item is paired with an icon in the UI. Only
+ *  facts we actually have are described — nothing is invented. */
+export function buildBookingPolicy(rental: RentalDetails): PolicyItem[] {
+  const items: PolicyItem[] = [];
+
+  const cancel = rental.freeCancellationMinutes;
+  items.push({
+    kind: 'cancellation',
+    text:
+      cancel && cancel > 0
+        ? `Free cancellation up to ${formatMinutes(cancel)} before your start time. After that, the booking is non-refundable.`
+        : 'Cancellation terms are set by the host and confirmed at checkout.',
+  });
+
+  if (rental.paymentOnline && rental.paymentInPerson) {
+    items.push({ kind: 'payment', text: 'Pay securely online now, or in person on arrival.' });
+  } else if (rental.paymentOnline) {
+    items.push({ kind: 'payment', text: 'Payment is collected securely online at checkout.' });
+  } else if (rental.paymentInPerson) {
+    items.push({ kind: 'payment', text: 'Reserve now and pay in person on arrival.' });
+  }
+
+  if (rental.maxParticipants === 1) {
+    items.push({ kind: 'capacity', text: 'Private booking — the space is reserved for you alone.' });
+  } else if (rental.maxParticipants && rental.maxParticipants > 1) {
+    items.push({
+      kind: 'capacity',
+      text: `Accommodates up to ${rental.maxParticipants} guests per booking.`,
+    });
+  }
+
+  return items;
+}
+
+export function formatTimeLabel(localDateTime: string): string {
+  // localDateTime is "YYYY-MM-DDThh:mm:ss" (no timezone) — parse the wall-clock parts.
+  const time = localDateTime.split('T')[1] ?? '';
+  const [hStr, mStr] = time.split(':');
+  const h = Number(hStr);
+  const m = Number(mStr);
+  if (Number.isNaN(h)) return localDateTime;
+  const period = h >= 12 ? 'PM' : 'AM';
+  const hour12 = h % 12 === 0 ? 12 : h % 12;
+  return `${hour12}:${String(m).padStart(2, '0')} ${period}`;
+}
+
+export function dayKeyOf(localDateTime: string): string {
+  return localDateTime.split('T')[0] ?? localDateTime;
+}
+
+export function formatDayLabel(dayKey: string): string {
+  const [y, m, d] = dayKey.split('-').map(Number);
+  if (!y || !m || !d) return dayKey;
+  const date = new Date(y, m - 1, d);
+  return date.toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  });
+}

--- a/astro/rentals/src/lib/rentals.ts
+++ b/astro/rentals/src/lib/rentals.ts
@@ -1,0 +1,555 @@
+import { wixClient, ensureVisitorSession, isClientConfigured, isLoggedIn } from './wix-client';
+import type {
+  AvailabilitySlot,
+  DurationRange,
+  Money,
+  RentalDetails,
+  RentalImage,
+  RentalSummary,
+} from './types';
+import {
+  dayKeyOf,
+  formatDayLabel,
+  formatDurationRange,
+  formatMinutes,
+  formatTimeLabel,
+  resolveWixImage,
+} from './format';
+
+export interface AvailabilityResult {
+  slots: AvailabilitySlot[];
+  timeZone?: string;
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Wix service objects are large/variadic; we read a defensive subset. The
+// generated SDK types are minified, so we call through an `any` view of the
+// client and validate the real runtime shapes against the live API.
+const client = wixClient as any;
+
+// Optionally restrict the catalog to a single Bookings app (by appId) — set
+// PUBLIC_WIX_RENTALS_APP_ID to your rentals app to hide yoga/other Bookings
+// services on the same site. When unset, all non-hidden services are listed.
+const RENTALS_APP_ID = (import.meta.env.PUBLIC_WIX_RENTALS_APP_ID ?? '').trim();
+
+// A media item's `image` may be a `wix:image://` string OR an object { url }.
+function mediaUrl(m: any): string | undefined {
+  if (!m) return undefined;
+  const raw =
+    (typeof m.image === 'string' ? m.image : m.image?.url) ??
+    m.url ??
+    (typeof m === 'string' ? m : undefined);
+  return resolveWixImage(raw);
+}
+function mediaAlt(m: any, fallback?: string): string | undefined {
+  return (typeof m?.image === 'object' ? m.image?.altText : undefined) ?? m?.altText ?? fallback;
+}
+
+function firstImage(service: any): RentalImage | undefined {
+  const m = service?.media?.mainMedia ?? service?.media?.items?.[0];
+  const url = mediaUrl(m);
+  return url ? { url, altText: mediaAlt(m, service?.name) } : undefined;
+}
+
+function allImages(service: any): RentalImage[] {
+  const items: any[] = service?.media?.items ?? [];
+  const imgs: RentalImage[] = [];
+  for (const m of items) {
+    const url = mediaUrl(m);
+    if (url) imgs.push({ url, altText: mediaAlt(m) });
+  }
+  const main = firstImage(service);
+  if (main && !imgs.some((img) => img.url === main.url)) imgs.unshift(main);
+  return imgs;
+}
+
+function priceOf(service: any): Money | undefined {
+  const p = service?.payment;
+  const fixed = p?.fixed?.price;
+  if (fixed) {
+    return { amount: fixed.value, currency: fixed.currency, formatted: fixed.formattedValue };
+  }
+  const varied = p?.varied?.defaultPrice;
+  if (varied) {
+    return { amount: varied.value, currency: varied.currency, formatted: varied.formattedValue };
+  }
+  if (p?.custom?.description) return { formatted: p.custom.description };
+  return undefined;
+}
+
+const MINUTES_PER_DAY = 24 * 60;
+
+function durationOf(service: any): string | undefined {
+  const range = durationRangeOf(service);
+  if (range) return formatDurationRange(range.minMinutes, range.maxMinutes);
+  const durations: number[] = service?.schedule?.availabilityConstraints?.sessionDurations ?? [];
+  if (durations.length) return formatMinutes(durations[0]);
+  return undefined;
+}
+
+// Wix duration shapes (verified against the live API):
+//   HOUR → durationRange.hourOptions.{minDurationInMinutes, maxDurationInMinutes}
+//   DAY  → durationRange.dayOptions.{minDurationInDays,   maxDurationInDays}
+function durationRangeOf(service: any): DurationRange | undefined {
+  const range = service?.schedule?.availabilityConstraints?.durationRange;
+  if (!range) return undefined;
+  if (range.unitType === 'HOUR' && range.hourOptions) {
+    const min = Number(range.hourOptions.minDurationInMinutes ?? 60);
+    return {
+      unit: 'HOUR',
+      minMinutes: min,
+      maxMinutes: Number(range.hourOptions.maxDurationInMinutes ?? min),
+    };
+  }
+  if (range.unitType === 'DAY' && range.dayOptions) {
+    const minDays = Number(range.dayOptions.minDurationInDays ?? 1);
+    const maxDays = Number(range.dayOptions.maxDurationInDays ?? minDays);
+    return {
+      unit: 'DAY',
+      minMinutes: minDays * MINUTES_PER_DAY,
+      maxMinutes: maxDays * MINUTES_PER_DAY,
+    };
+  }
+  return undefined;
+}
+
+function slugOf(service: any): string {
+  return service?.mainSlug?.name ?? service?.slug ?? service?._id ?? service?.id ?? '';
+}
+
+function toSummary(service: any): RentalSummary {
+  const category = service?.category;
+  const range = durationRangeOf(service);
+  const opts = service?.payment?.options;
+  return {
+    id: service?._id ?? service?.id ?? '',
+    slug: slugOf(service),
+    name: service?.name ?? 'Untitled rental',
+    tagLine: service?.tagLine || undefined,
+    description: service?.description || undefined,
+    image: firstImage(service),
+    category: category
+      ? { id: category.id ?? category._id, name: category.name }
+      : undefined,
+    price: priceOf(service),
+    durationLabel: durationOf(service),
+    rentalUnit: range?.unit,
+    minMinutes: range?.minMinutes,
+    maxMinutes: range?.maxMinutes,
+    priceUnit: range ? (range.unit === 'HOUR' ? 'hour' : 'day') : undefined,
+    paymentOnline: opts?.online === true,
+    paymentInPerson: opts?.inPerson === true,
+  };
+}
+
+function toDetails(service: any): RentalDetails {
+  const range = durationRangeOf(service);
+  const cancel = service?.bookingPolicy?.cancellationPolicy;
+  return {
+    ...toSummary(service),
+    images: allImages(service),
+    timeZone: service?.schedule?.availabilityConstraints?.timeZone ?? undefined,
+    durationRange: range,
+    priceUnit: range ? (range.unit === 'HOUR' ? 'hour' : 'day') : undefined,
+    freeCancellationMinutes: cancel?.enabled
+      ? Number(cancel.latestCancellationInMinutes ?? 0)
+      : undefined,
+    maxParticipants: service?.bookingPolicy?.participantsPolicy?.maxParticipantsPerBooking,
+  };
+}
+
+/** Run a Wix query whether it returns a builder (`.find()`) or a promise. */
+async function runQuery(query: any): Promise<any> {
+  if (query && typeof query.find === 'function') return query.find();
+  return query;
+}
+
+async function fetchAllServices(): Promise<any[]> {
+  await ensureVisitorSession();
+  const res = await runQuery(client.services.queryServices());
+  return res?.items ?? res?.services ?? [];
+}
+
+/** Bookable services, optionally scoped to a single Bookings app (see RENTALS_APP_ID). */
+async function fetchRentalServices(): Promise<any[]> {
+  const items = await fetchAllServices();
+  return items.filter(
+    (s) => s?.hidden !== true && (!RENTALS_APP_ID || s?.appId === RENTALS_APP_ID),
+  );
+}
+
+function resourceIdsOf(service: any): string[] {
+  const rs: any[] = service?.serviceResources ?? [];
+  return rs.flatMap((r) => r?.resourceIds?.values ?? []).filter(Boolean);
+}
+
+/** Load the features catalog (attribute definitions) + a resourceId→featureIds map.
+ *  Features are Bookings attributes assigned to the resource each service uses. */
+async function loadFeatureData(): Promise<{
+  defs: Map<string, { id: string; name: string }>;
+  byResource: Map<string, Set<string>>;
+}> {
+  const defs = new Map<string, { id: string; name: string }>();
+  const byResource = new Map<string, Set<string>>();
+  try {
+    const [defRes, valRes] = await Promise.all([
+      runQuery(client.attributeDefinition.queryAttributeDefinitions()),
+      runQuery(client.attributeValue.queryAttributeValues()),
+    ]);
+    for (const d of defRes?.items ?? []) {
+      const id = d?._id ?? d?.id;
+      if (id) defs.set(id, { id, name: d?.name ?? 'Feature' });
+    }
+    for (const v of valRes?.items ?? []) {
+      if (v?.boolData !== true || !v?.entityId || !v?.attributeDefinitionId) continue;
+      const set = byResource.get(v.entityId) ?? new Set<string>();
+      set.add(v.attributeDefinitionId);
+      byResource.set(v.entityId, set);
+    }
+  } catch {
+    /* attributes unavailable — features simply won't show */
+  }
+  return { defs, byResource };
+}
+
+export async function listRentals(): Promise<RentalSummary[]> {
+  const items = await fetchRentalServices();
+  const { defs, byResource } = await loadFeatureData();
+  return items
+    .map((s) => {
+      const featIds = new Set<string>();
+      for (const rid of resourceIdsOf(s)) {
+        for (const did of byResource.get(rid) ?? []) featIds.add(did);
+      }
+      const features = [...featIds]
+        .map((id) => defs.get(id))
+        .filter((f): f is { id: string; name: string } => Boolean(f));
+      return { ...toSummary(s), features };
+    })
+    .filter((r) => r.id);
+}
+
+export async function getRentalBySlug(slug: string): Promise<RentalDetails | undefined> {
+  const items = await fetchRentalServices();
+  const match = items.find(
+    (s) => slugOf(s) === slug || s?._id === slug || s?.id === slug,
+  );
+  if (!match) return undefined;
+  const details = toDetails(match);
+  const { defs, byResource } = await loadFeatureData();
+  const featIds = new Set<string>();
+  for (const rid of resourceIdsOf(match)) {
+    for (const did of byResource.get(rid) ?? []) featIds.add(did);
+  }
+  details.features = [...featIds]
+    .map((id) => defs.get(id))
+    .filter((f): f is { id: string; name: string } => Boolean(f));
+  return details;
+}
+
+function toSlotFromEntry(serviceId: string) {
+  return (entry: any, index: number): AvailabilitySlot => {
+    const slot = entry?.slot ?? {};
+    const startIso: string = slot.startDate ?? '';
+    const endIso: string = slot.endDate ?? '';
+    // slot.startDate is ISO with offset (e.g. 2026-07-04T21:30:00.000+01:00);
+    // the first 19 chars are the local wall-clock we display and key on.
+    const localStartDate = startIso.slice(0, 19);
+    const localEndDate = endIso.slice(0, 19);
+    const loc = slot.location;
+    return {
+      key: `${startIso || 'slot'}-${index}`,
+      serviceId,
+      localStartDate,
+      localEndDate,
+      dayKey: dayKeyOf(localStartDate),
+      startLabel: formatTimeLabel(localStartDate),
+      endLabel: formatTimeLabel(localEndDate),
+      bookable: entry?.bookable === true,
+      location: loc ? { name: loc.name, address: loc.formattedAddress } : undefined,
+      raw: entry,
+    };
+  };
+}
+
+// The business timezone (e.g. Europe/Dublin). queryAvailability returns UTC unless
+// given a timezone, so we resolve it once (via time-slots) and reuse it — this keeps
+// displayed slot times in the business's local time.
+let cachedTimeZone: string | undefined;
+async function siteTimeZone(serviceId: string): Promise<string | undefined> {
+  if (cachedTimeZone) return cachedTimeZone;
+  try {
+    const now = new Date();
+    const p = (n: number) => String(n).padStart(2, '0');
+    const from = `${now.getFullYear()}-${p(now.getMonth() + 1)}-${p(now.getDate())}T00:00:00`;
+    const later = new Date(now);
+    later.setDate(later.getDate() + 1);
+    const to = `${later.getFullYear()}-${p(later.getMonth() + 1)}-${p(later.getDate())}T00:00:00`;
+    const res: any = await client.availabilityTimeSlots.listAvailabilityTimeSlots({
+      serviceId,
+      fromLocalDate: from,
+      toLocalDate: to,
+      bookable: true,
+    });
+    cachedTimeZone = res?.timeZone;
+  } catch {
+    /* fall back to UTC */
+  }
+  return cachedTimeZone;
+}
+
+export async function getAvailability(
+  serviceId: string,
+  fromLocalDate: string,
+  toLocalDate: string,
+  timeZone?: string,
+): Promise<AvailabilityResult> {
+  await ensureVisitorSession();
+  const tz = timeZone ?? (await siteTimeZone(serviceId));
+  // Use queryAvailability: it returns the SlotAvailability shape that bookingsCheckout
+  // needs (a flat V2 time slot leaves the hosted booking form's serviceId empty). It
+  // filters by a UTC range, so widen a day on each side and filter back to local days.
+  const startUtc = new Date(`${fromLocalDate.slice(0, 10)}T00:00:00Z`);
+  startUtc.setUTCDate(startUtc.getUTCDate() - 1);
+  const endUtc = new Date(`${toLocalDate.slice(0, 10)}T23:59:59Z`);
+  endUtc.setUTCDate(endUtc.getUTCDate() + 1);
+  const res: any = await client.availabilityCalendar.queryAvailability(
+    {
+      filter: {
+        serviceId: [serviceId],
+        startDate: startUtc.toISOString(),
+        endDate: endUtc.toISOString(),
+      },
+    },
+    tz ? { timezone: tz } : undefined,
+  );
+  const entries: any[] = res?.availabilityEntries ?? [];
+  const fromDay = fromLocalDate.slice(0, 10);
+  const toDay = toLocalDate.slice(0, 10);
+  const slots = entries
+    .map(toSlotFromEntry(serviceId))
+    .filter((s) => s.localStartDate && s.dayKey >= fromDay && s.dayKey <= toDay);
+  return {
+    slots,
+    timeZone: tz ?? entries[0]?.slot?.timezone,
+  };
+}
+
+/** True if the service has at least one bookable slot in the given local range. */
+export async function hasAvailabilityInRange(
+  serviceId: string,
+  fromLocalDate: string,
+  toLocalDate: string,
+): Promise<boolean> {
+  const res = await getAvailability(serviceId, fromLocalDate, toLocalDate);
+  return res.slots.some((s) => s.bookable);
+}
+
+// Wix Bookings' eCommerce catalog app id — used as the `catalogReference.appId`
+// for a booking line item in the eCom checkout. The rental services belong to a
+// custom Bookings app, and the legacy `bookingsCheckout` redirect lands on the
+// standard `/__bookings/booking-form`, which rejects them ("service not valid").
+// Routing through the eCom checkout (createBooking → createCheckout → redirect)
+// works regardless of which app owns the service.
+const BOOKINGS_APP_DEF_ID = '13d21c63-b5ec-5912-8397-c3a5ddb27a97';
+
+interface MemberContact {
+  contactId?: string;
+  email?: string;
+  firstName?: string;
+  lastName?: string;
+}
+
+/** The logged-in member's contact identity, or null for anonymous visitors.
+ *  A member's bookings are scoped by the contact attached to the booking, so we
+ *  must stamp `contactDetails` (esp. `contactId`) on createBooking — otherwise
+ *  the booking is tied to an anonymous/guest contact and never shows up in the
+ *  member's account. */
+async function currentMemberContact(): Promise<MemberContact | null> {
+  if (!isLoggedIn()) return null;
+  try {
+    // FULL fieldset so we get loginEmail + contact name; contactId is present at
+    // any fieldset but the email/name only come back with FULL.
+    const res: any = await client.members.getCurrentMember({ fieldsets: ['FULL'] });
+    const m = res?.member ?? res;
+    if (!m) return null;
+    const contact: MemberContact = {
+      contactId: m.contactId ?? undefined,
+      email: m.loginEmail ?? undefined,
+      firstName: m.contact?.firstName ?? undefined,
+      lastName: m.contact?.lastName ?? undefined,
+    };
+    // Nothing to link on if we couldn't resolve either identifier.
+    return contact.contactId || contact.email ? contact : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Create a booking for the chosen SlotAvailability entry, wrap it in an eCom
+ *  checkout, then redirect the browser to the Wix-hosted checkout page. `entry`
+ *  is the queryAvailability entry (its `.slot.endDate` may already be extended
+ *  for multi-hour rentals). For a logged-in member we attach their contact so
+ *  the booking shows in their account; anonymous visitors supply contact details
+ *  on the hosted checkout page instead. */
+async function checkoutSlotEntry(entry: any): Promise<void> {
+  await ensureVisitorSession();
+  const slot = entry?.slot;
+  if (!slot) throw new Error('Could not start checkout — missing slot data.');
+
+  const contact = await currentMemberContact();
+
+  const created: any = await client.bookings.createBooking({
+    bookedEntity: { slot },
+    totalParticipants: 1,
+    ...(contact ? { contactDetails: contact } : {}),
+  });
+  const bookingId = created?.booking?._id;
+  if (!bookingId) throw new Error('Could not start checkout — booking was not created.');
+
+  const checkout: any = await client.checkout.createCheckout({
+    channelType: 'WEB',
+    lineItems: [
+      { quantity: 1, catalogReference: { appId: BOOKINGS_APP_DEF_ID, catalogItemId: bookingId } },
+    ],
+    // Seed the buyer email so the hosted checkout resolves to the member's
+    // contact (memberId/contactId on buyerInfo are read-only, derived from the
+    // member session that created the checkout).
+    ...(contact?.email ? { checkoutInfo: { buyerInfo: { email: contact.email } } } : {}),
+  });
+  const checkoutId = checkout?._id;
+  if (!checkoutId) throw new Error('Could not start checkout — no checkout was created.');
+
+  const res: any = await client.redirects.createRedirectSession({
+    ecomCheckout: { checkoutId },
+    callbacks: { postFlowUrl: `${window.location.origin}/confirmation` },
+  });
+  const url = res?.redirectSession?.fullUrl;
+  if (!url) throw new Error('Could not start checkout — no redirect URL returned.');
+  window.location.href = url;
+}
+
+/** Reserve a raw Wix SlotAvailability entry (optionally with an extended end for
+ *  multi-hour rentals) by creating a booking + eCom checkout and redirecting the
+ *  browser. */
+export async function reserve(rawSlot: unknown): Promise<void> {
+  await checkoutSlotEntry(rawSlot);
+}
+
+/* ---------------------------------------------------------- Member bookings
+   Requires a logged-in member session (see wix-client login helpers). */
+
+export interface MyBooking {
+  id: string;
+  revision: string;
+  serviceId: string;
+  title: string;
+  /** Human-friendly date/time of the booking. */
+  when: string;
+  startIso: string;
+  status: string; // CONFIRMED | PENDING | CANCELED | DECLINED | ...
+  unit: 'HOUR' | 'DAY';
+  durationMinutes: number;
+  /** Governed by the booking policy (server-computed allowedActions). */
+  canCancel: boolean;
+  canReschedule: boolean;
+}
+
+function toMyBooking(entry: any): MyBooking {
+  const b = entry?.booking ?? {};
+  const slot = b?.bookedEntity?.slot ?? {};
+  const startIso: string = slot.startDate ?? '';
+  const endIso: string = slot.endDate ?? '';
+  const startLocal = startIso.slice(0, 19);
+  const endLocal = endIso.slice(0, 19);
+  const durationMinutes =
+    startLocal && endLocal
+      ? Math.max(
+          0,
+          Math.round((new Date(endLocal).getTime() - new Date(startLocal).getTime()) / 60000),
+        )
+      : 0;
+  const unit: 'HOUR' | 'DAY' = slot?.durationUnitType === 'DAY' ? 'DAY' : 'HOUR';
+  const startDay = dayKeyOf(startLocal);
+  const days = Math.max(1, Math.round(durationMinutes / (24 * 60)));
+  const when =
+    unit === 'DAY'
+      ? `${formatDayLabel(startDay)} · ${days} day${days > 1 ? 's' : ''}`
+      : `${formatDayLabel(startDay)} · ${formatTimeLabel(startLocal)} – ${formatTimeLabel(endLocal)}`;
+  return {
+    id: b?._id ?? b?.id ?? '',
+    revision: String(b?.revision ?? ''),
+    serviceId: slot?.serviceId ?? b?.bookedEntity?.slot?.serviceId ?? '',
+    title: b?.bookedEntity?.title ?? 'Booking',
+    when,
+    startIso,
+    status: b?.status ?? 'CONFIRMED',
+    unit,
+    durationMinutes,
+    canCancel: entry?.allowedActions?.cancel === true,
+    canReschedule: entry?.allowedActions?.reschedule === true,
+  };
+}
+
+/** The logged-in member's bookings, newest first, with policy-driven allowed
+ *  actions. `withBookingAllowedActions` makes Wix compute cancel/reschedule
+ *  eligibility from the booking policy. (We deliberately skip
+ *  `withBookingPolicySettings`, which needs the extra
+ *  `BOOKINGS.BOOKING_POLICY_SNAPSHOT_READ` scope and isn't used here.) */
+export async function listMyBookings(): Promise<MyBooking[]> {
+  await ensureVisitorSession();
+  const res: any = await runQuery(
+    client.extendedBookings.queryExtendedBookings({
+      withBookingAllowedActions: true,
+    }),
+  );
+  const items: any[] = res?.items ?? res?.extendedBookings ?? [];
+  return items
+    .map(toMyBooking)
+    .filter((b) => b.id)
+    .sort((a, b) => (a.startIso < b.startIso ? 1 : -1));
+}
+
+export async function cancelMyBooking(bookingId: string, revision: string): Promise<void> {
+  await ensureVisitorSession();
+  await client.bookings.cancelBooking(bookingId, { revision });
+}
+
+/** Reschedule to a new slot. `newSlot` is a V2Slot (see buildRescheduledSlot). */
+export async function rescheduleMyBooking(
+  bookingId: string,
+  revision: string,
+  newSlot: unknown,
+): Promise<void> {
+  await ensureVisitorSession();
+  await client.bookings.rescheduleBooking(bookingId, newSlot, { revision });
+}
+
+// Add `minutes` to an ISO datetime with offset (e.g. 2026-07-15T09:00:00.000+01:00),
+// keeping the original UTC offset — used to preserve a booking's duration when the
+// start moves.
+function addMinutesToIso(iso: string, minutes: number): string {
+  const m = iso.match(/([+-]\d{2}:\d{2}|Z)$/);
+  const offset = m ? m[0] : 'Z';
+  const local = iso.slice(0, 19); // YYYY-MM-DDTHH:mm:ss
+  const d = new Date(`${local}Z`);
+  d.setUTCMinutes(d.getUTCMinutes() + minutes);
+  const p = (n: number) => String(n).padStart(2, '0');
+  const wall =
+    `${d.getUTCFullYear()}-${p(d.getUTCMonth() + 1)}-${p(d.getUTCDate())}` +
+    `T${p(d.getUTCHours())}:${p(d.getUTCMinutes())}:${p(d.getUTCSeconds())}`;
+  return `${wall}.000${offset}`;
+}
+
+/** Build the new slot for a reschedule: clone a fresh availability entry's slot
+ *  and stretch its end so the booking keeps its original length. `availEntry` is
+ *  the raw queryAvailability entry for the chosen new start. */
+export function buildRescheduledSlot(availEntry: any, durationMinutes: number): unknown {
+  const slot = JSON.parse(JSON.stringify(availEntry?.slot ?? {}));
+  if (slot.startDate && durationMinutes > 0) {
+    slot.endDate = addMinutesToIso(slot.startDate, durationMinutes);
+  }
+  return slot;
+}
+
+export { isClientConfigured };

--- a/astro/rentals/src/lib/types.ts
+++ b/astro/rentals/src/lib/types.ts
@@ -1,0 +1,77 @@
+/** Domain types the UI renders — decoupled from raw Wix SDK shapes. */
+
+export interface Money {
+  amount?: string;
+  currency?: string;
+  formatted?: string;
+}
+
+export interface RentalImage {
+  url: string;
+  altText?: string;
+}
+
+export interface RentalCategory {
+  id?: string;
+  name?: string;
+}
+
+export interface RentalSummary {
+  id: string;
+  slug: string;
+  name: string;
+  tagLine?: string;
+  description?: string;
+  image?: RentalImage;
+  category?: RentalCategory;
+  price?: Money;
+  durationLabel?: string;
+  /** 'HOUR' | 'DAY' — drives the Hourly/Daily badge and rental-type filter. */
+  rentalUnit?: 'HOUR' | 'DAY';
+  minMinutes?: number;
+  maxMinutes?: number;
+  priceUnit?: string;
+  paymentOnline?: boolean;
+  paymentInPerson?: boolean;
+  /** Features (Bookings attributes) assigned to this rental's resource. */
+  features?: { id: string; name: string }[];
+}
+
+export interface DurationRange {
+  unit: 'HOUR' | 'DAY';
+  minMinutes: number;
+  maxMinutes: number;
+}
+
+export interface RentalDetails extends RentalSummary {
+  images: RentalImage[];
+  timeZone?: string;
+  durationRange?: DurationRange;
+  /** 'hour' | 'day' — the unit the price applies to, derived from the duration range. */
+  priceUnit?: string;
+  /** Minutes before start that free cancellation is allowed (if enabled). */
+  freeCancellationMinutes?: number;
+  maxParticipants?: number;
+}
+
+/** A single line of the booking policy, rendered with a matching icon. */
+export interface PolicyItem {
+  kind: 'cancellation' | 'payment' | 'capacity';
+  text: string;
+}
+
+/** A single bookable time slot, normalized for the UI + checkout hand-off. */
+export interface AvailabilitySlot {
+  /** Synthesized React key — Wix time slots have no id. */
+  key: string;
+  serviceId: string;
+  localStartDate: string;
+  localEndDate: string;
+  dayKey: string; // YYYY-MM-DD
+  startLabel: string; // e.g. "9:00 AM"
+  endLabel: string;
+  bookable: boolean;
+  location?: { name?: string; address?: string };
+  /** The original Wix SlotAvailability entry, passed to bookingsCheckout. */
+  raw: unknown;
+}

--- a/astro/rentals/src/lib/wix-client.ts
+++ b/astro/rentals/src/lib/wix-client.ts
@@ -1,0 +1,169 @@
+import { createClient, OAuthStrategy } from '@wix/sdk';
+import {
+  services,
+  availabilityCalendar,
+  availabilityTimeSlots,
+  attributeDefinition,
+  attributeValue,
+  bookings,
+  extendedBookings,
+} from '@wix/bookings';
+import { members } from '@wix/members';
+import { checkout } from '@wix/ecom';
+import { redirects } from '@wix/redirects';
+
+const TOKENS_KEY = 'wix-rentals:session';
+// Headless OAuth Client ID (a public, non-secret value) read from the env at
+// build time. Set PUBLIC_WIX_CLIENT_ID in your .env — see .env.example.
+const CLIENT_ID = (import.meta.env.PUBLIC_WIX_CLIENT_ID ?? '').trim();
+
+export const isClientConfigured = CLIENT_ID.length > 0;
+
+/** Tokens are persisted so the same visitor session survives reloads + the
+ *  round-trip through Wix-hosted checkout. Structurally compatible with the
+ *  SDK's Tokens type. */
+type StoredTokens = Parameters<typeof OAuthStrategy>[0]['tokens'];
+
+function loadTokens(): StoredTokens | undefined {
+  try {
+    const raw = localStorage.getItem(TOKENS_KEY);
+    return raw ? (JSON.parse(raw) as StoredTokens) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function saveTokens(tokens: StoredTokens): void {
+  try {
+    localStorage.setItem(TOKENS_KEY, JSON.stringify(tokens));
+  } catch {
+    /* ignore quota / privacy-mode errors */
+  }
+}
+
+if (!isClientConfigured && typeof console !== 'undefined') {
+  console.error(
+    '[wix-rentals] Missing PUBLIC_WIX_CLIENT_ID. Set it in .env to your ' +
+      'Headless OAuth Client ID (see .env.example).',
+  );
+}
+
+export const wixClient = createClient({
+  modules: {
+    services,
+    availabilityCalendar,
+    availabilityTimeSlots,
+    attributeDefinition,
+    attributeValue,
+    bookings,
+    extendedBookings,
+    members,
+    checkout,
+    redirects,
+  },
+  auth: OAuthStrategy({
+    clientId: CLIENT_ID,
+    tokens: loadTokens(),
+  }),
+});
+
+function clearTokens(): void {
+  try {
+    localStorage.removeItem(TOKENS_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+let sessionPromise: Promise<void> | null = null;
+
+/** Ensure a valid session exists and is persisted. If a member is already logged
+ *  in, their session is kept as-is; otherwise an anonymous visitor session is
+ *  generated. Safe to call repeatedly — the work runs once per page load. */
+export function ensureVisitorSession(): Promise<void> {
+  if (!isClientConfigured) return Promise.resolve();
+  // Don't overwrite a logged-in member session with anonymous visitor tokens.
+  if (wixClient.auth.loggedIn()) return Promise.resolve();
+  if (!sessionPromise) {
+    sessionPromise = (async () => {
+      const tokens = await wixClient.auth.generateVisitorTokens(loadTokens());
+      saveTokens(tokens);
+    })().catch((err) => {
+      // Reset so a later call can retry after a transient failure.
+      sessionPromise = null;
+      throw err;
+    });
+  }
+  return sessionPromise;
+}
+
+/* ------------------------------------------------------------------ Members
+   Wix Headless member login uses the OAuth "managed login" redirect flow. */
+
+const OAUTH_KEY = 'wix-rentals:oauth';
+
+export function isLoggedIn(): boolean {
+  return isClientConfigured && wixClient.auth.loggedIn();
+}
+
+/** Redirect the browser to the Wix-hosted login page. On success Wix redirects
+ *  back to `/login-callback`, which must be whitelisted in the Headless OAuth
+ *  app settings. `returnTo` is where the user lands after logging in. */
+export async function login(returnTo = '/account'): Promise<void> {
+  const redirectUri = `${window.location.origin}/login-callback`;
+  const origin = `${window.location.origin}${returnTo}`;
+  const oauthData = wixClient.auth.generateOAuthData(redirectUri, origin);
+  sessionStorage.setItem(OAUTH_KEY, JSON.stringify(oauthData));
+  const { authUrl } = await wixClient.auth.getAuthUrl(oauthData, { prompt: 'login' });
+  window.location.href = authUrl;
+}
+
+/** Exchange the OAuth callback for member tokens and persist them. Returns the
+ *  path to send the user back to. Call this on the `/login-callback` route. */
+export async function completeLogin(): Promise<string> {
+  const raw = sessionStorage.getItem(OAUTH_KEY);
+  if (!raw) throw new Error('Your login session expired. Please try signing in again.');
+  const oauthData = JSON.parse(raw);
+  const { code, state, error, errorDescription } = wixClient.auth.parseFromUrl();
+  if (error) throw new Error(errorDescription || error);
+  const tokens = await wixClient.auth.getMemberTokens(code, state, oauthData);
+  wixClient.auth.setTokens(tokens);
+  saveTokens(tokens);
+  sessionStorage.removeItem(OAUTH_KEY);
+  // generateOAuthData stored our returnTo in `originalUri` — resolve it to a path.
+  try {
+    return new URL(oauthData.originalUri).pathname || '/account';
+  } catch {
+    return '/account';
+  }
+}
+
+/** Log the member out (clears the session and redirects through Wix's logout). */
+export async function logout(): Promise<void> {
+  const { logoutUrl } = await wixClient.auth.logout(window.location.origin);
+  clearTokens();
+  sessionPromise = null;
+  window.location.href = logoutUrl;
+}
+
+/** The currently logged-in member's profile, or null. */
+export async function getCurrentMember(): Promise<{
+  id?: string;
+  name?: string;
+  email?: string;
+  photo?: string;
+} | null> {
+  if (!isLoggedIn()) return null;
+  // FULL fieldset: PUBLIC omits loginEmail + contact, so the name/email would
+  // otherwise be missing.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const res: any = await (wixClient as any).members.getCurrentMember({ fieldsets: ['FULL'] });
+  const m = res?.member ?? res;
+  if (!m) return null;
+  return {
+    id: m._id ?? m.id,
+    name: m.profile?.nickname || m.contact?.firstName || m.loginEmail || 'Member',
+    email: m.loginEmail,
+    photo: m.profile?.photo?.url,
+  };
+}

--- a/astro/rentals/src/pages/[...path].astro
+++ b/astro/rentals/src/pages/[...path].astro
@@ -1,0 +1,11 @@
+---
+// Catch-all: serve the React SPA shell for every deep route (e.g.
+// /rental/:slug, /confirmation) so direct loads + refreshes work.
+// react-router renders the correct view on the client.
+import Layout from '../layouts/Layout.astro';
+import App from '../App';
+---
+
+<Layout>
+	<App client:only="react" />
+</Layout>

--- a/astro/rentals/src/pages/index.astro
+++ b/astro/rentals/src/pages/index.astro
@@ -1,0 +1,8 @@
+---
+import Layout from '../layouts/Layout.astro';
+import App from '../App';
+---
+
+<Layout>
+	<App client:only="react" />
+</Layout>

--- a/astro/rentals/src/styles/global.css
+++ b/astro/rentals/src/styles/global.css
@@ -1,0 +1,184 @@
+@import 'tailwindcss';
+
+@theme {
+  --font-sans: 'Inter', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto,
+    Helvetica, Arial, sans-serif;
+
+  /* Cool neutral palette — restrained, professional.
+     Token names kept (cream/ink/etc.) so utility classes stay stable. */
+  --color-cream: #f6f7f9; /* page background */
+  --color-cream-deep: #eceef2; /* placeholders, footer, subtle chips */
+  --color-surface: #ffffff;
+  --color-ink: #141820; /* near-black, slightly cool */
+  --color-ink-soft: #414855;
+  --color-muted: #767e8b;
+  --color-line: #e4e7ec;
+
+  /* Professional blue accent (aliased to brand-* so legacy classes stay on-palette) */
+  --color-accent: #2563eb;
+  --color-accent-hover: #1d4ed8;
+  --color-accent-soft: #eaf1fe;
+  --color-brand-50: #eff5ff;
+  --color-brand-100: #dbe6fe;
+  --color-brand-400: #5b8def;
+  --color-brand-500: #2563eb;
+  --color-brand-600: #1d4ed8;
+  --color-brand-700: #1e40af;
+}
+
+html {
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  color: var(--color-ink);
+  background: var(--color-cream);
+}
+
+::selection {
+  background: var(--color-accent-soft);
+}
+
+/* Consistent, accessible focus ring for keyboard users. */
+:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* ---------------------------------------------------------------- Animation
+   Small, tasteful motion. Every animation is disabled under
+   prefers-reduced-motion (see the media query at the bottom). */
+
+@keyframes card-in {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes scale-in {
+  from {
+    opacity: 0;
+    transform: scale(0.97) translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+@keyframes sheet-up {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes modal-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes pop-in {
+  0% {
+    opacity: 0;
+    transform: scale(0.6);
+  }
+  60% {
+    transform: scale(1.06);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.animate-card-in {
+  animation: card-in 0.5s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+.animate-fade-in {
+  animation: fade-in 0.3s ease-out both;
+}
+.animate-fade-up {
+  animation: fade-up 0.5s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+.animate-scale-in {
+  animation: scale-in 0.16s cubic-bezier(0.22, 1, 0.36, 1) both;
+  transform-origin: top;
+}
+.animate-sheet-up {
+  animation: sheet-up 0.3s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+.animate-pop-in {
+  animation: pop-in 0.45s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+/* Modal panel: slides up as a sheet on mobile, scales in when centered. */
+.animate-modal {
+  animation: sheet-up 0.3s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+@media (min-width: 640px) {
+  .animate-modal {
+    animation: modal-in 0.2s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+}
+
+/* Subtle hover lift for cards and primary CTAs. */
+.hover-lift {
+  transition:
+    transform 0.2s cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 0.2s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.hover-lift:hover {
+  transform: translateY(-2px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-card-in,
+  .animate-fade-in,
+  .animate-fade-up,
+  .animate-scale-in,
+  .animate-sheet-up,
+  .animate-pop-in,
+  .animate-modal {
+    animation: none;
+  }
+  .hover-lift:hover {
+    transform: none;
+  }
+}

--- a/astro/rentals/src/views/Account.tsx
+++ b/astro/rentals/src/views/Account.tsx
@@ -1,0 +1,235 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../lib/auth';
+import { cancelMyBooking, listMyBookings, type MyBooking } from '../lib/rentals';
+import { Avatar, EmptyState, ErrorNote, Spinner } from '../components/ui';
+import { RescheduleModal } from '../components/RescheduleModal';
+import { UserIcon } from '../components/icons';
+
+function StatusBadge({ status }: { status: string }) {
+  const s = status.toUpperCase();
+  const tone =
+    s === 'CONFIRMED'
+      ? 'bg-green-100 text-green-700'
+      : s === 'PENDING' || s === 'PENDING_APPROVAL' || s === 'WAITING_LIST'
+        ? 'bg-amber-100 text-amber-700'
+        : s === 'CANCELED' || s === 'DECLINED'
+          ? 'bg-cream-deep text-muted'
+          : 'bg-cream-deep text-ink-soft';
+  const label = s.charAt(0) + s.slice(1).toLowerCase().replace(/_/g, ' ');
+  return <span className={`rounded-full px-2.5 py-1 text-xs font-medium ${tone}`}>{label}</span>;
+}
+
+export function Account() {
+  const { member, loggedIn, loading: authLoading, login, logout } = useAuth();
+  const [bookings, setBookings] = useState<MyBooking[]>([]);
+  const [loading, setLoading] = useState(loggedIn);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [confirmingId, setConfirmingId] = useState<string | null>(null);
+  const [rescheduling, setRescheduling] = useState<MyBooking | null>(null);
+  const [loggingIn, setLoggingIn] = useState(false);
+
+  const load = useCallback(() => {
+    if (!loggedIn) return;
+    setLoading(true);
+    setError(null);
+    listMyBookings()
+      .then(setBookings)
+      .catch((e) => setError(e?.message ?? 'Could not load your bookings.'))
+      .finally(() => setLoading(false));
+  }, [loggedIn]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (authLoading) return <Spinner label="Loading your account…" />;
+
+  if (!loggedIn) {
+    return (
+      <div className="mx-auto flex max-w-md flex-col px-4 py-20 sm:px-6">
+        <div className="animate-fade-up flex flex-col items-center rounded-2xl border border-line bg-surface p-8 text-center shadow-sm">
+          <span className="flex h-14 w-14 items-center justify-center rounded-full bg-cream-deep text-ink">
+            <UserIcon size={26} />
+          </span>
+          <h1 className="mt-5 text-xl font-semibold tracking-tight text-ink">
+            Log in to view your account
+          </h1>
+          <p className="mt-2 text-sm leading-relaxed text-muted">
+            Browsing and booking are open to everyone — sign in only to see and manage the bookings
+            tied to your account.
+          </p>
+          <button
+            type="button"
+            disabled={loggingIn}
+            onClick={() => {
+              setLoggingIn(true);
+              login('/account').catch(() => setLoggingIn(false));
+            }}
+            className="mt-6 flex w-full items-center justify-center gap-2 rounded-xl bg-accent px-5 py-3 text-sm font-semibold text-white transition-colors hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {loggingIn && (
+              <span className="h-4 w-4 animate-spin rounded-full border-2 border-white/40 border-t-white" />
+            )}
+            {loggingIn ? 'Signing in…' : 'Log in or sign up'}
+          </button>
+          <Link
+            to="/"
+            className="mt-3 text-sm font-medium text-muted transition-colors hover:text-ink"
+          >
+            Continue browsing
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const doCancel = async (b: MyBooking) => {
+    setBusyId(b.id);
+    setActionError(null);
+    try {
+      await cancelMyBooking(b.id, b.revision);
+      setConfirmingId(null);
+      load();
+    } catch (e) {
+      setActionError((e as Error)?.message ?? 'Could not cancel this booking.');
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 pb-24 pt-8 sm:px-6">
+      {/* Profile header */}
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex items-center gap-4">
+          <Avatar name={member?.name} photo={member?.photo} className="h-14 w-14" textClass="text-lg" />
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight text-ink">{member?.name}</h1>
+            {member?.email && <p className="text-sm text-muted">{member.email}</p>}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={logout}
+          className="rounded-xl border border-line bg-surface px-4 py-2 text-sm font-medium text-ink transition-colors hover:border-accent"
+        >
+          Log out
+        </button>
+      </div>
+
+      <h2 className="mt-10 text-xl font-semibold tracking-tight text-ink">My bookings</h2>
+
+      {actionError && (
+        <div className="mt-4">
+          <ErrorNote title="Something went wrong" detail={actionError} />
+        </div>
+      )}
+
+      {loading ? (
+        <Spinner label="Loading your bookings…" />
+      ) : error ? (
+        <div className="mt-4">
+          <ErrorNote title="Couldn’t load your bookings" detail={error} />
+        </div>
+      ) : bookings.length === 0 ? (
+        <div className="mt-4">
+          <EmptyState title="No bookings yet">
+            When you book a space it’ll show up here.{' '}
+            <Link to="/" className="font-medium text-accent hover:text-accent-hover">
+              Browse spaces
+            </Link>
+          </EmptyState>
+        </div>
+      ) : (
+        <ul className="mt-4 space-y-3">
+          {bookings.map((b) => {
+            const canceled = b.status.toUpperCase() === 'CANCELED' || b.status.toUpperCase() === 'DECLINED';
+            const hasActions = b.canCancel || b.canReschedule;
+            return (
+              <li
+                key={b.id}
+                className="animate-fade-in rounded-2xl border border-line bg-surface p-4 shadow-sm"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="font-semibold text-ink">{b.title}</p>
+                    <p className="mt-0.5 text-sm text-muted">{b.when}</p>
+                  </div>
+                  <StatusBadge status={b.status} />
+                </div>
+
+                {confirmingId === b.id ? (
+                  <div className="mt-3 flex items-center gap-3 border-t border-line pt-3 text-sm">
+                    <span className="text-ink-soft">Cancel this booking?</span>
+                    <button
+                      type="button"
+                      disabled={busyId === b.id}
+                      onClick={() => doCancel(b)}
+                      className="rounded-lg bg-red-600 px-3 py-1.5 font-medium text-white transition-colors hover:bg-red-700 disabled:opacity-60"
+                    >
+                      {busyId === b.id ? 'Cancelling…' : 'Yes, cancel'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setConfirmingId(null)}
+                      className="text-muted transition-colors hover:text-ink"
+                    >
+                      Keep it
+                    </button>
+                  </div>
+                ) : hasActions ? (
+                  <div className="mt-3 flex gap-2 border-t border-line pt-3">
+                    {b.canReschedule && (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setActionError(null);
+                          setRescheduling(b);
+                        }}
+                        className="rounded-lg border border-line px-3 py-1.5 text-sm font-medium text-ink transition-colors hover:border-accent"
+                      >
+                        Reschedule
+                      </button>
+                    )}
+                    {b.canCancel && (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setActionError(null);
+                          setConfirmingId(b.id);
+                        }}
+                        className="rounded-lg border border-line px-3 py-1.5 text-sm font-medium text-red-600 transition-colors hover:border-red-300 hover:bg-red-50"
+                      >
+                        Cancel
+                      </button>
+                    )}
+                  </div>
+                ) : (
+                  !canceled && (
+                    <p className="mt-3 border-t border-line pt-3 text-xs text-muted">
+                      Changes aren’t available for this booking under its policy.
+                    </p>
+                  )
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {rescheduling && (
+        <RescheduleModal
+          booking={rescheduling}
+          onClose={() => setRescheduling(null)}
+          onDone={() => {
+            setRescheduling(null);
+            load();
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/astro/rentals/src/views/Confirmation.tsx
+++ b/astro/rentals/src/views/Confirmation.tsx
@@ -1,0 +1,55 @@
+import { Link, useSearchParams } from 'react-router-dom';
+import { CheckCircleIcon, RefreshIcon } from '../components/icons';
+
+export function Confirmation() {
+  const [params] = useSearchParams();
+  const orderId = params.get('orderId');
+  const bookingId = params.get('bookingId');
+  // Wix sends an error hint back on the callback if the flow was abandoned/failed.
+  const failed = params.get('error') || params.get('status') === 'failed';
+
+  return (
+    <div className="animate-fade-up mx-auto max-w-2xl px-4 py-20 text-center sm:px-6">
+      <div
+        className={`animate-pop-in mx-auto flex h-16 w-16 items-center justify-center rounded-full ${
+          failed ? 'bg-amber-100 text-amber-600' : 'bg-green-100 text-green-600'
+        }`}
+      >
+        {failed ? <RefreshIcon size={30} /> : <CheckCircleIcon size={32} />}
+      </div>
+
+      <h1 className="mt-6 text-2xl font-semibold tracking-tight text-ink">
+        {failed ? 'Checkout not completed' : 'Booking confirmed'}
+      </h1>
+      <p className="mx-auto mt-2 max-w-md text-muted">
+        {failed
+          ? 'Looks like the checkout was cancelled. The space is still available — feel free to try again.'
+          : 'Thanks for your booking. A confirmation has been sent to your email, and the details are saved in your Wix account.'}
+      </p>
+
+      {(orderId || bookingId) && !failed && (
+        <dl className="mx-auto mt-6 w-full max-w-sm rounded-xl border border-line bg-surface p-4 text-left text-sm">
+          {orderId && (
+            <div className="flex justify-between gap-4 py-1">
+              <dt className="text-muted">Order</dt>
+              <dd className="font-mono text-ink">{orderId}</dd>
+            </div>
+          )}
+          {bookingId && (
+            <div className="flex justify-between gap-4 py-1">
+              <dt className="text-muted">Booking</dt>
+              <dd className="font-mono text-ink">{bookingId}</dd>
+            </div>
+          )}
+        </dl>
+      )}
+
+      <Link
+        to="/"
+        className="mt-8 inline-block rounded-xl bg-accent px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-accent-hover"
+      >
+        Browse more spaces
+      </Link>
+    </div>
+  );
+}

--- a/astro/rentals/src/views/LoginCallback.tsx
+++ b/astro/rentals/src/views/LoginCallback.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useRef, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { completeLogin } from '../lib/wix-client';
+import { useAuth } from '../lib/auth';
+import { ErrorNote, Spinner } from '../components/ui';
+
+export function LoginCallback() {
+  const navigate = useNavigate();
+  const { refresh } = useAuth();
+  const [error, setError] = useState<string | null>(null);
+  const ran = useRef(false);
+
+  useEffect(() => {
+    // parseFromUrl consumes the one-time code — guard against React's double-invoke.
+    if (ran.current) return;
+    ran.current = true;
+    completeLogin()
+      .then((to) => {
+        refresh();
+        navigate(to, { replace: true });
+      })
+      .catch((e) => setError(e?.message ?? 'Could not complete sign-in.'));
+  }, [navigate, refresh]);
+
+  if (error) {
+    return (
+      <div className="mx-auto max-w-md px-4 py-20 text-center sm:px-6">
+        <ErrorNote title="Sign-in failed" detail={error} />
+        <Link
+          to="/"
+          className="mt-4 inline-block font-medium text-accent hover:text-accent-hover"
+        >
+          ← Back to spaces
+        </Link>
+      </div>
+    );
+  }
+  return <Spinner label="Signing you in…" />;
+}

--- a/astro/rentals/src/views/RentalDetail.tsx
+++ b/astro/rentals/src/views/RentalDetail.tsx
@@ -1,0 +1,264 @@
+import { useEffect, useState } from 'react';
+import { Link, useParams, useSearchParams } from 'react-router-dom';
+import { getAvailability, getRentalBySlug } from '../lib/rentals';
+import type { PolicyItem, RentalDetails } from '../lib/types';
+import { ReservationPanel } from '../components/ReservationPanel';
+import { DayReservationPanel } from '../components/DayReservationPanel';
+import { EmptyState, ErrorNote, Spinner } from '../components/ui';
+import { buildBookingPolicy, formatMoney } from '../lib/format';
+import {
+  BuildingIcon,
+  CardIcon,
+  ChevronLeftIcon,
+  MapPinIcon,
+  ShieldIcon,
+  UsersIcon,
+} from '../components/icons';
+import { isClientConfigured } from '../lib/wix-client';
+
+interface LocationInfo {
+  name?: string;
+  address?: string;
+}
+
+const POLICY_ICON: Record<PolicyItem['kind'], typeof ShieldIcon> = {
+  cancellation: ShieldIcon,
+  payment: CardIcon,
+  capacity: UsersIcon,
+};
+
+export function RentalDetail() {
+  const { slug = '' } = useParams();
+  const [searchParams] = useSearchParams();
+  const initialDate = searchParams.get('date') ?? undefined;
+
+  const [rental, setRental] = useState<RentalDetails | undefined>();
+  const [loading, setLoading] = useState(isClientConfigured);
+  const [notFound, setNotFound] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [activeImage, setActiveImage] = useState(0);
+  const [location, setLocation] = useState<LocationInfo | null>(null);
+
+  useEffect(() => {
+    if (!isClientConfigured) return;
+    let cancelled = false;
+    setLoading(true);
+    setNotFound(false);
+    getRentalBySlug(slug)
+      .then((r) => {
+        if (cancelled) return;
+        if (!r) {
+          setNotFound(true);
+          return;
+        }
+        setRental(r);
+        // Fetch a small availability window to surface the location up-front.
+        const now = new Date();
+        const pad = (n: number) => String(n).padStart(2, '0');
+        const fmt = (d: Date) =>
+          `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T00:00:00`;
+        const to = new Date(now);
+        to.setDate(to.getDate() + 7);
+        getAvailability(r.id, fmt(now), fmt(to))
+          .then((res) => {
+            if (cancelled) return;
+            if (res.slots[0]?.location) setLocation(res.slots[0].location);
+          })
+          .catch(() => {});
+      })
+      .catch((e) => !cancelled && setError(e?.message ?? 'Failed to load this rental.'))
+      .finally(() => !cancelled && setLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
+
+  if (!isClientConfigured) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6">
+        <EmptyState title="Connect your Wix site first">
+          Add <code>PUBLIC_WIX_CLIENT_ID</code> to a <code>.env</code> file to load space details.
+        </EmptyState>
+      </div>
+    );
+  }
+  if (loading) return <Spinner label="Loading space…" />;
+  if (error) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-12 sm:px-6">
+        <ErrorNote title="Something went wrong" detail={error} />
+      </div>
+    );
+  }
+  if (notFound || !rental) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-16 text-center sm:px-6">
+        <EmptyState title="Space not found">
+          This space may have been removed. Browse the full list to find another.
+        </EmptyState>
+        <Link to="/" className="mt-4 inline-block font-medium text-accent hover:text-accent-hover">
+          ← All spaces
+        </Link>
+      </div>
+    );
+  }
+
+  const price = formatMoney(rental.price);
+  const images = rental.images;
+  const hero = images[activeImage] ?? images[0];
+  const range = rental.durationRange;
+  const policy = buildBookingPolicy(rental);
+
+  // Concise meta line — category and rental type. Duration lives in the
+  // reservation panel and location on its own line, so neither is repeated here.
+  const meta: string[] = [];
+  if (rental.category?.name) meta.push(rental.category.name);
+  if (range) meta.push(range.unit === 'HOUR' ? 'Booked by the hour' : 'Booked by the day');
+
+  // Show the location once — prefer the full address, fall back to its name.
+  const locationText = location?.address ?? location?.name;
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 pb-24 pt-6 sm:px-6">
+      <Link
+        to="/"
+        className="inline-flex items-center gap-1.5 text-sm font-medium text-muted transition-colors hover:text-ink"
+      >
+        <ChevronLeftIcon size={16} /> Back to spaces
+      </Link>
+
+      {/* Hero */}
+      <div className="animate-fade-up mt-4 overflow-hidden rounded-2xl border border-line bg-cream-deep">
+        {hero ? (
+          <img
+            src={hero.url}
+            alt={hero.altText ?? rental.name}
+            className="h-[240px] w-full object-cover sm:h-[380px]"
+          />
+        ) : (
+          <div className="flex h-[240px] w-full items-center justify-center text-muted sm:h-[380px]">
+            <BuildingIcon size={72} />
+          </div>
+        )}
+      </div>
+      {images.length > 1 && (
+        <div className="mt-3 flex gap-2 overflow-x-auto pb-1">
+          {images.map((img, i) => (
+            <button
+              key={img.url}
+              type="button"
+              onClick={() => setActiveImage(i)}
+              aria-label={`View image ${i + 1}`}
+              className={`h-16 w-24 shrink-0 overflow-hidden rounded-lg border-2 transition-colors ${
+                i === activeImage ? 'border-accent' : 'border-transparent hover:border-line'
+              }`}
+            >
+              <img src={img.url} alt="" className="h-full w-full object-cover" />
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Body */}
+      <div className="mt-8 grid gap-10 lg:grid-cols-[1fr_360px]">
+        <div>
+          <div className="flex items-start justify-between gap-4">
+            <h1 className="text-3xl font-semibold tracking-tight text-ink sm:text-4xl">
+              {rental.name}
+            </h1>
+            {price && (
+              <div className="whitespace-nowrap text-right">
+                <span className="text-2xl font-semibold text-ink">{price}</span>
+                {rental.priceUnit && <span className="text-sm text-muted"> / {rental.priceUnit}</span>}
+              </div>
+            )}
+          </div>
+
+          {meta.length > 0 && (
+            <p className="mt-3 text-sm leading-relaxed text-muted">
+              {meta.map((m, i) => (
+                <span key={m}>
+                  {i > 0 && <span className="px-2 text-line">•</span>}
+                  {m}
+                </span>
+              ))}
+            </p>
+          )}
+
+          {locationText && (
+            <p className="mt-3 flex items-center gap-1.5 text-sm text-ink-soft">
+              <MapPinIcon size={16} className="shrink-0 text-muted" />
+              {locationText}
+            </p>
+          )}
+
+          {rental.description && (
+            <p className="mt-6 whitespace-pre-line leading-relaxed text-ink-soft">
+              {rental.description}
+            </p>
+          )}
+
+          {rental.features && rental.features.length > 0 && (
+            <div className="mt-10">
+              <h2 className="text-xl font-semibold tracking-tight text-ink">What’s included</h2>
+              <div className="mt-4 flex flex-wrap gap-2">
+                {rental.features.map((f) => (
+                  <span
+                    key={f.id}
+                    className="rounded-full border border-line bg-surface px-4 py-2 text-sm text-ink"
+                  >
+                    {f.name}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Booking policy — cancellation, payment and capacity in plain language. */}
+          {policy.length > 0 && (
+            <div className="mt-10">
+              <h2 className="text-xl font-semibold tracking-tight text-ink">Booking policy</h2>
+              <ul className="mt-4 space-y-3.5 rounded-2xl border border-line bg-surface p-5">
+                {policy.map((item) => {
+                  const PolicyIcon = POLICY_ICON[item.kind];
+                  return (
+                    <li key={item.kind} className="flex items-start gap-3 text-sm text-ink-soft">
+                      <PolicyIcon size={18} className="mt-0.5 shrink-0 text-accent" />
+                      <span className="leading-relaxed">{item.text}</span>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+        </div>
+
+        {/* Reservation card — day rentals use a date-range picker, hourly rentals
+            use a single-day + time-slot picker. */}
+        <div className="lg:sticky lg:top-24 lg:self-start">
+          {range?.unit === 'DAY' ? (
+            <DayReservationPanel
+              serviceId={rental.id}
+              minDays={Math.max(1, Math.round((range.minMinutes ?? 1440) / (24 * 60)))}
+              maxDays={Math.max(1, Math.round((range.maxMinutes ?? range.minMinutes ?? 1440) / (24 * 60)))}
+              priceLabel={price}
+              priceUnit={rental.priceUnit}
+              initialDate={initialDate}
+              onLocation={setLocation}
+            />
+          ) : (
+            <ReservationPanel
+              serviceId={rental.id}
+              minMinutes={range?.minMinutes ?? 60}
+              maxMinutes={range?.maxMinutes ?? range?.minMinutes ?? 60}
+              priceLabel={price}
+              priceUnit={rental.priceUnit}
+              initialDate={initialDate}
+              onLocation={setLocation}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/astro/rentals/src/views/RentalsList.tsx
+++ b/astro/rentals/src/views/RentalsList.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useMemo, useState } from 'react';
+import { hasAvailabilityInRange, listRentals } from '../lib/rentals';
+import type { RentalSummary } from '../lib/types';
+import { RentalCard } from '../components/RentalCard';
+import { DateRangeSearch, type DateRange } from '../components/DateRangeSearch';
+import { EMPTY_FILTERS, FilterModal, type RentalFilters } from '../components/FilterModal';
+import { EmptyState, ErrorNote, Spinner } from '../components/ui';
+import { FilterIcon } from '../components/icons';
+import { isClientConfigured } from '../lib/wix-client';
+
+export function RentalsList() {
+  const [rentals, setRentals] = useState<RentalSummary[]>([]);
+  const [loading, setLoading] = useState(isClientConfigured);
+  const [error, setError] = useState<string | null>(null);
+
+  const [range, setRange] = useState<DateRange | null>(null);
+  const [availableIds, setAvailableIds] = useState<Set<string> | null>(null);
+  const [availLoading, setAvailLoading] = useState(false);
+
+  const [filters, setFilters] = useState<RentalFilters>(EMPTY_FILTERS);
+  const [filterOpen, setFilterOpen] = useState(false);
+  const [category, setCategory] = useState('all');
+
+  useEffect(() => {
+    if (!isClientConfigured) return;
+    let cancelled = false;
+    listRentals()
+      .then((r) => !cancelled && setRentals(r))
+      .catch((e) => !cancelled && setError(e?.message ?? 'Failed to load rentals.'))
+      .finally(() => !cancelled && setLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Availability filtering — only when a date range is applied.
+  useEffect(() => {
+    if (!range || rentals.length === 0) {
+      setAvailableIds(null);
+      return;
+    }
+    let cancelled = false;
+    setAvailLoading(true);
+    const from = `${range.start}T00:00:00`;
+    const to = `${range.end}T23:59:59`;
+    Promise.all(
+      rentals.map((r) =>
+        hasAvailabilityInRange(r.id, from, to)
+          .then((ok) => (ok ? r.id : null))
+          .catch(() => null),
+      ),
+    )
+      .then((ids) => {
+        if (!cancelled) setAvailableIds(new Set(ids.filter((x): x is string => Boolean(x))));
+      })
+      .finally(() => !cancelled && setAvailLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [range, rentals]);
+
+  const featureOptions = useMemo(() => {
+    const map = new Map<string, string>();
+    rentals.forEach((r) => r.features?.forEach((f) => map.set(f.id, f.name)));
+    return [...map].map(([id, name]) => ({ id, name }));
+  }, [rentals]);
+
+  const categories = useMemo(() => {
+    const set = new Set<string>();
+    rentals.forEach((r) => r.category?.name && set.add(r.category.name));
+    return [...set].sort();
+  }, [rentals]);
+
+  const activeFilterCount =
+    filters.features.length + filters.rentalTypes.length + filters.payment.length;
+
+  const filtered = useMemo(() => {
+    return rentals.filter((r) => {
+      if (category !== 'all' && r.category?.name !== category) return false;
+      if (filters.rentalTypes.length && !(r.rentalUnit && filters.rentalTypes.includes(r.rentalUnit)))
+        return false;
+      if (
+        filters.payment.length &&
+        !filters.payment.some((p) => (p === 'online' ? r.paymentOnline : r.paymentInPerson))
+      )
+        return false;
+      if (filters.features.length) {
+        const ids = new Set((r.features ?? []).map((f) => f.id));
+        if (!filters.features.every((id) => ids.has(id))) return false;
+      }
+      if (range && availableIds && !filters.showUnavailable && !availableIds.has(r.id)) return false;
+      return true;
+    });
+  }, [rentals, category, filters, range, availableIds]);
+
+  // Signature of the current result set — changes when filtering settles, which
+  // remounts the grid and replays the staggered entrance animation.
+  const resultKey = filtered.map((r) => r.id).join(',');
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 sm:px-6">
+      {/* Search + filter toolbar */}
+      <section className="pt-6 sm:pt-8">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <DateRangeSearch onApply={setRange} initial={range} />
+          <button
+            type="button"
+            onClick={() => setFilterOpen(true)}
+            className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-line bg-surface px-5 py-3 text-sm font-medium text-ink shadow-sm transition-colors hover:border-accent sm:w-auto"
+          >
+            <FilterIcon size={16} /> Filters
+            {activeFilterCount > 0 && (
+              <span className="ml-1 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-accent px-1.5 text-xs text-white">
+                {activeFilterCount}
+              </span>
+            )}
+          </button>
+        </div>
+      </section>
+
+      {/* Category filters + results */}
+      <div className="mt-8">
+        {categories.length > 0 && (
+          <div className="mb-8 flex flex-wrap items-center gap-3">
+            {['all', ...categories].map((cat) => (
+              <button
+                key={cat}
+                type="button"
+                onClick={() => setCategory(cat)}
+                className={`rounded-full px-4 py-2 text-sm font-medium transition-colors ${
+                  category === cat ? 'bg-ink text-white' : 'bg-cream-deep text-ink-soft hover:bg-line'
+                }`}
+              >
+                {cat === 'all' ? 'All spaces' : cat}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {!isClientConfigured ? (
+          <EmptyState title="Connect your Wix site to see spaces">
+            Add your Headless <code>PUBLIC_WIX_CLIENT_ID</code> to a <code>.env</code> file and
+            restart the dev server.
+          </EmptyState>
+        ) : loading ? (
+          <Spinner label="Loading spaces…" />
+        ) : error ? (
+          <ErrorNote title="Couldn’t load spaces" detail={error} />
+        ) : (
+          <>
+            {availLoading && (
+              <div className="mb-6 inline-flex items-center gap-2.5 rounded-full border border-line bg-surface px-4 py-2 text-sm font-medium text-ink-soft shadow-sm">
+                <span className="h-4 w-4 animate-spin rounded-full border-2 border-accent-soft border-t-accent" />
+                Filtering spaces for your dates…
+              </div>
+            )}
+            {filtered.length === 0 ? (
+              <EmptyState title="No spaces match your filters">
+                Try clearing filters or choosing different dates.
+              </EmptyState>
+            ) : (
+              <div
+                key={resultKey}
+                className={`grid grid-cols-1 gap-x-6 gap-y-9 pb-10 transition-opacity duration-300 sm:grid-cols-2 lg:grid-cols-3 ${
+                  availLoading ? 'opacity-40' : 'opacity-100'
+                }`}
+              >
+                {filtered.map((rental, i) => (
+                  <div
+                    key={rental.id}
+                    className="animate-card-in"
+                    style={{ animationDelay: `${Math.min(i, 8) * 60}ms` }}
+                  >
+                    <RentalCard rental={rental} queryDate={range?.start} />
+                  </div>
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      <FilterModal
+        open={filterOpen}
+        initial={filters}
+        featureOptions={featureOptions}
+        onApply={(f) => {
+          setFilters(f);
+          setFilterOpen(false);
+        }}
+        onClose={() => setFilterOpen(false)}
+      />
+    </div>
+  );
+}

--- a/astro/rentals/tsconfig.json
+++ b/astro/rentals/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "include": [".astro/types.d.ts", "**/*"],
+  "exclude": ["dist"]
+}


### PR DESCRIPTION
## Summary

Adds a new Astro template, **`astro/rentals`** — a headless space-rentals storefront built on Wix Bookings.

### What it demonstrates
- Browse & filter rentable spaces backed by Wix Bookings services
- **Hourly and daily** reservations with a live availability calendar
- **Hosted checkout** via the Wix eCom checkout redirect (booking → checkout → redirect)
- **Member area** (Wix Headless OAuth) to view / cancel / reschedule bookings
- Anonymous visitor session for browsing; login only required for the account area

Stack: Astro 5 (server output) · React 18 + react-router · Tailwind v4 · `@wix/sdk`, `@wix/bookings`, `@wix/ecom`, `@wix/members`, `@wix/redirects`.

### Setup / env
- `PUBLIC_WIX_CLIENT_ID` (required) — Headless OAuth Client ID
- `PUBLIC_WIX_RENTALS_APP_ID` (optional) — restrict the catalog to one Bookings app; lists all non-hidden services when unset

See `astro/rentals/README.md` and `.env.example`. No secrets, `wix.config.json`, or lockfiles are committed.

### Notes for reviewers
- Uses `wix dev` / `wix build` (Wix CLI + `output: "server"`), like the `store` / `hello` templates rather than Family-A's `astro dev`/`build`. Happy to switch if preferred.
- Member login uses a manual `createClient` + `OAuthStrategy` (localStorage sessions) since the app needs member auth in a `client:only` React SPA.

### Known limitation
The member **My bookings** list can return empty even when a booking is correctly attached to the member in the dashboard. The checkout already stamps the member `contactId` + buyer email; the read-side scoping is still under investigation and will be addressed in a follow-up.
