### PR TITLE
docs: fix broken Wix CLI Headless Quick Start link in Astro READMEs

### DIFF
--- a/astro/README.md
+++ b/astro/README.md
@@ -2,7 +2,7 @@
 
 Our Astro templates are still in development and subject to change.
 
-To use a template, follow the [Wix CLI for Headless Quick Start](https://dev.wix.com/docs/go-headless/develop-your-project/wix-managed-headless/get-started/quick-start), and select the desired template during the setup process.
+To use a template, follow the [Wix CLI for Headless Quick Start](https://dev.wix.com/docs/go-headless/get-started/quick-starts/wix-managed-headless/quick-start-with-the-wix-cli), and select the desired template during the setup process.
 
 ## Need help?
 

--- a/astro/astrowind/README.md
+++ b/astro/astrowind/README.md
@@ -2,7 +2,7 @@
 
 Our Astro templates are still in development and subject to change.
 
-To use a template, follow the [Wix CLI for Headless Quick Start](https://dev.wix.com/docs/go-headless/develop-your-project/wix-managed-headless/get-started/quick-start), and select the desired template during the setup process.
+To use a template, follow the [Wix CLI for Headless Quick Start](https://dev.wix.com/docs/go-headless/get-started/quick-starts/wix-managed-headless/quick-start-with-the-wix-cli), and select the desired template during the setup process.
 
 ## Need help?
 

--- a/astro/blank/README.md
+++ b/astro/blank/README.md
@@ -2,7 +2,7 @@
 
 Our Astro templates are still in development and subject to change.
 
-To use a template, follow the [Wix CLI for Headless Quick Start](https://dev.wix.com/docs/go-headless/develop-your-project/wix-managed-headless/get-started/quick-start), and select the desired template during the setup process.
+To use a template, follow the [Wix CLI for Headless Quick Start](https://dev.wix.com/docs/go-headless/get-started/quick-starts/wix-managed-headless/quick-start-with-the-wix-cli), and select the desired template during the setup process.
 
 ## Need help?
 

--- a/astro/blog/README.md
+++ b/astro/blog/README.md
@@ -2,7 +2,7 @@
 
 Our Astro templates are still in development and subject to change.
 
-To use a template, follow the [Wix CLI for Headless Quick Start](https://dev.wix.com/docs/go-headless/develop-your-project/wix-managed-headless/get-started/quick-start), and select the desired template during the setup process.
+To use a template, follow the [Wix CLI for Headless Quick Start](https://dev.wix.com/docs/go-headless/get-started/quick-starts/wix-managed-headless/quick-start-with-the-wix-cli), and select the desired template during the setup process.
 
 ## Need help?
 

--- a/astro/commerce/README.md
+++ b/astro/commerce/README.md
@@ -2,7 +2,7 @@
 
 Our Astro templates are still in development and subject to change.
 
-To use a template, follow the [Wix CLI for Headless Quick Start](https://dev.wix.com/docs/go-headless/develop-your-project/wix-managed-headless/get-started/quick-start), and select the desired template during the setup process.
+To use a template, follow the [Wix CLI for Headless Quick Start](https://dev.wix.com/docs/go-headless/get-started/quick-starts/wix-managed-headless/quick-start-with-the-wix-cli), and select the desired template during the setup process.
 
 ## Need help?
 

--- a/astro/registration/README.md
+++ b/astro/registration/README.md
@@ -2,7 +2,7 @@
 
 Our Astro templates are still in development and subject to change.
 
-To use a template, follow the [Wix CLI for Headless Quick Start](https://dev.wix.com/docs/go-headless/develop-your-project/wix-managed-headless/get-started/quick-start), and select the desired template during the setup process.
+To use a template, follow the [Wix CLI for Headless Quick Start](https://dev.wix.com/docs/go-headless/get-started/quick-starts/wix-managed-headless/quick-start-with-the-wix-cli), and select the desired template during the setup process.
 
 ## Need help?
 

--- a/astro/scheduler/README.md
+++ b/astro/scheduler/README.md
@@ -2,7 +2,7 @@
 
 Our Astro templates are still in development and subject to change.
 
-To use a template, follow the [Wix CLI for Headless Quick Start](https://dev.wix.com/docs/go-headless/develop-your-project/wix-managed-headless/get-started/quick-start), and select the desired template during the setup process.
+To use a template, follow the [Wix CLI for Headless Quick Start](https://dev.wix.com/docs/go-headless/get-started/quick-starts/wix-managed-headless/quick-start-with-the-wix-cli), and select the desired template during the setup process.
 
 ## Need help?
 


### PR DESCRIPTION
The Wix-managed Headless Quick Start doc moved to a new URL, leaving the link in the Astro template READMEs broken.

This updates all Astro READMEs to point to the new location:

- Old: `https://dev.wix.com/docs/go-headless/develop-your-project/wix-managed-headless/get-started/quick-start`
- New: `https://dev.wix.com/docs/go-headless/get-started/quick-starts/wix-managed-headless/quick-start-with-the-wix-cli`

Files changed (7):
- `astro/README.md`
- `astro/blank/README.md`
- `astro/astrowind/README.md`
- `astro/blog/README.md`
- `astro/commerce/README.md`
- `astro/registration/README.md`
- `astro/scheduler/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)