### PR TITLE
feat: add templates.json manifest as the CLI template catalog

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -1,0 +1,37 @@
+{
+  "version": 1,
+  "templates": [
+    {
+      "name": "commerce",
+      "title": "Commerce (Wix Stores)",
+      "subtitle": "Product catalog, checkout, and more",
+      "siteTemplateId": "e5da13f4-c01e-4b61-a9c7-55dacd961d54",
+      "gitPath": "astro/commerce",
+      "vibeCompatible": false
+    },
+    {
+      "name": "scheduler",
+      "title": "Scheduler (Wix Bookings)",
+      "subtitle": "Appointment booking and calendar",
+      "siteTemplateId": "72ade0e3-1871-4c04-ac54-419ca874d9d3",
+      "gitPath": "astro/scheduler",
+      "vibeCompatible": false
+    },
+    {
+      "name": "registration",
+      "title": "Registration (Wix Forms)",
+      "subtitle": "Inputs, dropdowns and field validations",
+      "siteTemplateId": "e5d63bf1-cd06-48eb-ad77-0da9235adcf1",
+      "gitPath": "astro/registration",
+      "vibeCompatible": false
+    },
+    {
+      "name": "blank",
+      "title": "Blank",
+      "subtitle": "Basic Astro project",
+      "siteTemplateId": "212b41cb-0da6-4401-9c72-7c579e6477a2",
+      "gitPath": "astro/blank",
+      "vibeCompatible": false
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds a `templates.json` manifest at the repo root, pairing each CLI-exposed Astro template with its Wix site template ID (`siteTemplateId`), display metadata, and repo path (`gitPath`).

## Why

The Wix CLI (`wix headless`) currently hardcodes this catalog, so adding or updating a template requires a CLI release, and the code-template ↔ site-template pairing can drift. With this manifest the CLI fetches the catalog at runtime from this repo, making it the single source of truth: merging a change here updates every installed CLI immediately.

The initial content mirrors the CLI's current hardcoded list exactly (commerce, scheduler, registration, blank).

## Notes

- The CLI reads `https://raw.githubusercontent.com/wix/headless-templates/main/templates.json`.
- Unknown fields are ignored by the CLI's parser, so the manifest can gain metadata without breaking older CLI versions.
- The corresponding CLI change lands in wix-private/wix-cli and should release only after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)