### PR TITLE
Add blog template to templates.json manifest

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -29,7 +29,7 @@
       "name": "blog",
       "title": "Blog (Wix Blog)",
       "subtitle": "Posts, categories, and rich content",
-      "siteTemplateId": "7bde072d-f967-4085-806c-6a7aeac794e0",
+      "siteTemplateId": "808ff67a-fe03-428e-bbee-9b10ee5f6b28",
       "gitPath": "astro/blog",
       "vibeCompatible": false
     },

--- a/templates.json
+++ b/templates.json
@@ -26,6 +26,14 @@
       "vibeCompatible": false
     },
     {
+      "name": "blog",
+      "title": "Blog (Wix Blog)",
+      "subtitle": "Posts, categories, and rich content",
+      "siteTemplateId": "7bde072d-f967-4085-806c-6a7aeac794e0",
+      "gitPath": "astro/blog",
+      "vibeCompatible": false
+    },
+    {
       "name": "blank",
       "title": "Blank",
       "subtitle": "Basic Astro project",


### PR DESCRIPTION
## Summary
- Adds a `blog` entry to `templates.json` (Wix Blog template), pointing at `astro/blog`.
- `siteTemplateId` is `808ff67a-fe03-428e-bbee-9b10ee5f6b28` — a Wix site template minted from the live blog site (`7bde072d-f967-4085-806c-6a7aeac794e0`) via the `headless-business-setup` wix-templates endpoint, not the live site's own ID (an earlier version of this PR mistakenly used the raw site ID).
- Rebased onto current `main`.

## Test plan
- [x] Minted the Wix site template via `POST /headless-business-setup/v1/headless-sites/wix-templates/{metaSiteId}?name=blog` and confirmed the response `wixTemplateId`.
- [ ] Verify `astro/blog` scaffolds correctly via the CLI template catalog using the new `siteTemplateId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)