### PR TITLE
fix: add wix hosting adapter to registration template

### DIFF
--- a/astro/registration/astro.config.mjs
+++ b/astro/registration/astro.config.mjs
@@ -2,10 +2,13 @@
 import { defineConfig } from "astro/config";
 import wix from "@wix/astro";
 import wixPages from "@wix/astro-pages";
+import wixHostingAdapter from "@wix/astro-wix-hosting-adapter";
 import tailwindcss from "@tailwindcss/vite";
 
 // https://astro.build/config
 export default defineConfig({
+  output: "server",
+  adapter: wixHostingAdapter(),
   integrations: [wix(), wixPages()],
   security: { checkOrigin: false },
   vite: {

--- a/astro/registration/package.json
+++ b/astro/registration/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.1.7",
     "@wix/astro": "^2.39.0",
+    "@wix/astro-wix-hosting-adapter": "^2.0.0",
     "@wix/astro-pages": "^2.0.4",
     "@wix/dashboard": "^1.3.36",
     "@wix/essentials": "^1.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1631,6 +1631,7 @@
         "@tailwindcss/vite": "^4.1.7",
         "@wix/astro": "^2.39.0",
         "@wix/astro-pages": "^2.0.4",
+        "@wix/astro-wix-hosting-adapter": "^2.0.0",
         "@wix/dashboard": "^1.3.36",
         "@wix/essentials": "^1.0.6",
         "@wix/forms": "^1.0.259",


### PR DESCRIPTION
## What

Adds `@wix/astro-wix-hosting-adapter` (+ `output: "server"`) to `astro/registration`, matching scheduler/commerce/blog.

## Why

Registration was the one template missed by the #686 adapter migration — its server-rendered build fails with `NoAdapterInstalled` outside the CLI context, which blocks publishing its bundle to the headless registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)