### PR TITLE
docs: add live demo links to Astro template READMEs

### DIFF
--- a/astro/blank/README.md
+++ b/astro/blank/README.md
@@ -1,5 +1,7 @@
 # Wix Astro Blank Template
 
+**[Live demo](https://h6s-1a31f9730cd85b-headlessstack.wix-site-host.com)**
+
 Our Astro templates are still in development and subject to change.
 
 To use a template, follow the [Wix CLI for Headless Quick Start](https://dev.wix.com/docs/go-headless/get-started/quick-starts/wix-managed-headless/quick-start-with-the-wix-cli), and select the desired template during the setup process.

--- a/astro/commerce/README.md
+++ b/astro/commerce/README.md
@@ -1,5 +1,7 @@
 # Wix Astro Commerce Template
 
+**[Live demo](https://jlgivq-headlessstack.wix-app-host.com)**
+
 A minimal Astro + React storefront wireframe backed by Wix Stores and Wix eCommerce. It exists to show the right way to wire an Astro site to Wix business solutions — the UI is a thin starting point for your own design.
 
 ## How it connects to Wix

--- a/astro/scheduler/README.md
+++ b/astro/scheduler/README.md
@@ -1,5 +1,7 @@
 # Wix Astro Scheduler Template
 
+**[Live demo](https://h6s-50cfc9db5d48fc-headlessstack.wix-site-host.com)**
+
 An appointment scheduling template built with Astro and [Wix Bookings](https://dev.wix.com/docs/sdk/backend-modules/bookings/introduction). It demonstrates the full booking flow against a Wix site:
 
 - Listing bookable services with `@wix/bookings` (`services.queryServices`)


### PR DESCRIPTION
Adds a **Live demo** link to the top of the blank, commerce, and scheduler Astro template READMEs, pointing at each template's deployed demo site (taken from the headless-bo templates registry, all verified returning 200).

Registration is skipped — its registry entry has no deployed site yet (bundle exceeds the deploy-validation payload limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)